### PR TITLE
fixed search input height

### DIFF
--- a/src/components/Navigation/Topnav.less
+++ b/src/components/Navigation/Topnav.less
@@ -57,7 +57,7 @@
   }
 
   input {
-    height: 54px !important;
+    height: 55px !important;
     border-radius: 0 !important;
     border: 0 !important;
     padding: 0 0 0 15px !important;


### PR DESCRIPTION
The search input was 1px to small, which resulted in this double border.

![utopian-search-height](https://user-images.githubusercontent.com/6792578/32202896-3ec8aee0-bde0-11e7-8308-13f50a30dcd1.png)
