### PR TITLE
Editor: Place Cursor & Newline After Inserted Image

### DIFF
--- a/src/components/Comments/CommentForm.js
+++ b/src/components/Comments/CommentForm.js
@@ -60,16 +60,24 @@ class CommentForm extends React.Component {
     }
   };
 
+  setInputCursorPosition = (pos) => {
+    if (this.input && this.input.setSelectionRange) {
+      this.input.setSelectionRange(pos, pos);
+    }
+  }
+
   insertImage = (image, imageName = 'image') => {
     if (!this.input) return;
 
     const startPos = this.input.selectionStart;
     const endPos = this.input.selectionEnd;
+    const imageText = `![${imageName}](${image})\n`;
     const newValue = `${this.input.value.substring(
       0,
       startPos,
-    )}![${imageName}](${image})${this.input.value.substring(endPos, this.input.value.length)}\n`;
+    )}${imageText}${this.input.value.substring(endPos, this.input.value.length)}`;
     this.setState({ inputValue: newValue });
+    this.setInputCursorPosition(startPos + imageText.length);
   };
 
   handleCommentTextChange = (e) => {

--- a/src/components/Comments/EmbeddedCommentForm.js
+++ b/src/components/Comments/EmbeddedCommentForm.js
@@ -57,16 +57,24 @@ class EmbeddedCommentForm extends React.Component {
     }
   };
 
+  setInputCursorPosition = (pos) => {
+    if (this.input && this.input.setSelectionRange) {
+      this.input.setSelectionRange(pos, pos);
+    }
+  }
+
   insertImage = (image, imageName = 'image') => {
     if (!this.input) return;
 
     const startPos = this.input.selectionStart;
     const endPos = this.input.selectionEnd;
+    const imageText = `![${imageName}](${image})\n`;
     const newValue = `${this.input.value.substring(
       0,
       startPos,
-    )}![${imageName}](${image})${this.input.value.substring(endPos, this.input.value.length)}\n`;
+    )}${imageText}${this.input.value.substring(endPos, this.input.value.length)}`;
     this.setState({ inputValue: newValue });
+    this.setInputCursorPosition(startPos + imageText.length);
   };
 
   handleCommentTextChange = (e) => {

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -240,6 +240,12 @@ class Editor extends React.Component {
     return values;
   };
 
+  setInputCursorPosition = (pos) => {
+    if (this.input && this.input.setSelectionRange) {
+      this.input.setSelectionRange(pos, pos);
+    }
+  }
+
   resizeTextarea = () => {
     if (this.originalInput) this.originalInput.resizeTextarea();
   };
@@ -401,13 +407,14 @@ class Editor extends React.Component {
 
     const startPos = this.input.selectionStart;
     const endPos = this.input.selectionEnd;
+    const imageText = `![${imageName}](${image})\n`;
     this.input.value = `${this.input.value.substring(
       0,
       startPos,
-    )}![${imageName}](${image})${this.input.value.substring(endPos, this.input.value.length)}\n`;
-
+    )}${imageText}${this.input.value.substring(endPos, this.input.value.length)}`;
     this.resizeTextarea();
     this.renderMarkdown(this.input.value);
+    this.setInputCursorPosition(startPos + imageText.length);
     this.onUpdate();
   };
 


### PR DESCRIPTION
Wanted to give things a go with bringing over bug fixes from the Busy upstream. Not sure if you're open to these kind of PRs right now, so just let me know.

If you find this useful, I'll file it on Utopian and look at what other bug fixes / features can be brought over easily.

### Original Busy Commit
Editor: Place Cursor & Newline After Inserted Image (#912)

This fix ensures that, when inserting an image:
- the newline placed after the image is no longer placed at the end of the input
- the cursor is no longer placed at the end of the input