### PR TITLE
Able to search fork projects as well

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -5,12 +5,12 @@ import * as querystring from 'querystring';
 export const getProjectsRequest = q => ({
   [CALL_API]: {
     types: [ Actions.GET_PROJECTS_REQUEST, Actions.GET_PROJECTS_SUCCESS, Actions.GET_PROJECTS_FAILURE ],
-    //endpoint: `https://api.github.com/search/repositories?q=${q}&sort=stars&order=desc`,
-    endpoint: `https://api.github.com/search/repositories?${querystring.encode(q)}`,
+    endpoint: `https://api.github.com/search/repositories?${querystring.encode(q)}+fork:true&sort=stars&order=desc`,
+    //endpoint: `https://api.github.com/search/repositories?${querystring.encode(q)}`,
     schema: null,
     method: 'GET',
     payload: {},
-    additionalParams: {},
+    additionalParams: {fork:true},
     absolute: true
   }
 });


### PR DESCRIPTION
Previous end point https://api.github.com/search/repositories?${querystring.encode(q)} was encoding the +fork:true as well. If that is encode, github did not recognize it. So we need to encode only q part and add +fork:true&sort=stars&order=desc.