### PR TITLE
Feature/add access to old sc2 drafts

### DIFF
--- a/src/auth/authActions.js
+++ b/src/auth/authActions.js
@@ -4,6 +4,7 @@ import Cookie from 'js-cookie';
 import { getFollowing } from '../user/userActions';
 import { initPushpad } from '../helpers/pushpadHelper';
 import { getDrafts } from '../helpers/localStorageHelpers';
+import { getDraftsSC2 } from '../helpers/metadata';
 
 Promise.promisifyAll(steemConnect);
 
@@ -34,6 +35,7 @@ export const login = () => (dispatch) => {
           }
 
           initPushpad(resp.user, Cookie.get('access_token'));
+          resp.draftsSC2 = resp.drafts;
           resp.drafts = getDrafts();
           return resp;
         }),

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -51,6 +51,7 @@ class Editor extends React.Component {
     onSubmit: PropTypes.func,
     onError: PropTypes.func,
     onImageInserted: PropTypes.func,
+    displayUpdateBtn: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -70,6 +71,7 @@ class Editor extends React.Component {
     onSubmit: () => {},
     onError: () => {},
     onImageInserted: () => {},
+    displayUpdateBtn: true,
   };
 
   static hotkeys = {
@@ -498,8 +500,8 @@ class Editor extends React.Component {
 
   render() {
     const { getFieldDecorator } = this.props.form;
-    const { intl, loading, isUpdating, isReviewed, type, saving, getProjects, projects, setProjects, user, getPullRequests, pullRequests } = this.props;
-
+    const { intl, loading, isUpdating, isReviewed, type, saving, getProjects, projects, setProjects, user, getPullRequests, pullRequests, displayUpdateBtn } = this.props;
+	
     const chosenType = this.state.currentType || type || 'ideas';
 
     return (
@@ -891,6 +893,7 @@ class Editor extends React.Component {
                   defaultMessage="Styling with markdown supported"
                 />
               </span>
+            {displayUpdateBtn && (
             <div className="Editor__bottom__right">
               {saving && (
                 <span className="Editor__bottom__right__saving">
@@ -921,6 +924,7 @@ class Editor extends React.Component {
                   )}
               </Form.Item>
             </div>
+            )}
           </div>
         </div>
       </Form>

--- a/src/post/Write/DraftRowSC2.js
+++ b/src/post/Write/DraftRowSC2.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'antd';
+import { FormattedMessage } from 'react-intl';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { deleteDraftSC2 } from './editorActions';
+
+@connect(null, { deleteDraftSC2 })
+class DraftRowSC2 extends React.Component {
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    data: PropTypes.shape().isRequired,
+    pending: PropTypes.bool,
+    deleteDraftSC2: PropTypes.func,
+  };
+
+  static defaultProps = {
+    pending: false,
+    deleteDraftSC2: () => {},
+  };
+
+  handleDeleteClick = () => this.props.deleteDraftSC2(this.props.id);
+
+  render() {
+    const { id, data, pending } = this.props;
+    let { title = '', body = '' } = data;
+    title = title.trim();
+    body = body.replace(/\r?\n|\r|[\u200B-\u200D\uFEFF]/g, ' ').substring(0, 50);
+    let draftTitle = title.length ? title : body;
+    draftTitle = draftTitle.trim();
+
+    const type = data.jsonMetadata.type || '';
+    const repository = data.jsonMetadata.repository || {};
+
+    return (
+      <div>
+        <Link to={{ pathname: type.indexOf('task') > -1 ? `/write-task-sc2/${repository.id}` : '/write-sc2', search: `?draft=${id}` }}>
+          <h3>
+            {draftTitle.length === 0 ? <FormattedMessage id="draft_untitled" defaultMessage="Untitled draft" /> : draftTitle}
+          </h3>
+        </Link>
+        <div>
+          <Button loading={pending} type="danger" onClick={this.handleDeleteClick} disabled={true}>
+            <FormattedMessage id="draft_delete" defaultMessage="Delete this draft" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default DraftRowSC2;

--- a/src/post/Write/DraftsSC2.js
+++ b/src/post/Write/DraftsSC2.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { connect } from 'react-redux';
+import _ from 'lodash';
+import Loading from '../../components/Icon/Loading';
+import { reload } from '../../auth/authActions';
+import { getDraftPostsSC2, getPendingDraftsSC2, getIsReloading } from '../../reducers';
+import Affix from '../../components/Utils/Affix';
+import LeftSidebar from '../../app/Sidebar/LeftSidebar';
+import DraftRowSC2 from './DraftRowSC2';
+
+@connect(
+  state => ({
+    reloading: getIsReloading(state),
+    draftPostsSC2: getDraftPostsSC2(state),
+    pendingDraftsSC2: getPendingDraftsSC2(state),
+  }),
+  { reload },
+)
+class DraftsSC2 extends React.Component {
+  static propTypes = {
+    reloading: PropTypes.bool,
+    draftPostsSC2: PropTypes.shape().isRequired,
+    pendingDraftsSC2: PropTypes.arrayOf(PropTypes.string),
+    reload: PropTypes.func,
+  };
+
+  static defaultProps = {
+    reloading: false,
+    pendingDraftsSC2: [],
+    reload: () => {},
+  };
+
+  componentDidMount() {
+    this.props.reload();
+  }
+
+  render() {
+    const { reloading, draftPostsSC2, pendingDraftsSC2 } = this.props;
+
+    const noDrafts = !reloading && _.size(draftPostsSC2) === 0;
+
+    return (
+      <div className="shifted">
+        <div className="settings-layout container">
+          <Affix className="leftContainer" stickPosition={77}>
+            <div className="left">
+              <LeftSidebar />
+            </div>
+          </Affix>
+          <div className="center">
+            <h1>
+              <FormattedMessage id="drafts" defaultMessage="Drafts" />
+            </h1>
+            {reloading && <Loading center={false} />}
+            {noDrafts && (
+              <h3 className="text-center">
+                <FormattedMessage
+                  id="drafts_empty"
+                  defaultMessage="You don't have any draft saved"
+                />
+              </h3>
+            )}
+            {!reloading &&
+              _.map(draftPostsSC2, (draft, key) => (
+                <DraftRowSC2 key={key} data={draft} id={key} pending={pendingDraftsSC2.includes(key)} />
+              ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default DraftsSC2;

--- a/src/post/Write/WriteSC2.js
+++ b/src/post/Write/WriteSC2.js
@@ -1,0 +1,417 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import kebabCase from 'lodash/kebabCase';
+import debounce from 'lodash/debounce';
+import isArray from 'lodash/isArray';
+import 'url-search-params-polyfill';
+import { injectIntl } from 'react-intl';
+
+import {
+  getAuthenticatedUser,
+  getDraftPostsSC2,
+  getIsEditorLoading,
+  getIsEditorSaving,
+} from '../../reducers';
+
+import * as Actions from '../../actions/constants';
+import { createPost, saveDraftSC2, newPost } from './editorActions';
+import { notify } from '../../app/Notification/notificationActions';
+import Editor from '../../components/Editor/Editor';
+import Affix from '../../components/Utils/Affix';
+
+const version = require('../../../package.json').version;
+
+// @UTOPIAN
+import { Modal, Icon } from 'antd';
+import { getBeneficiaries } from '../../actions/beneficiaries';
+import { getStats } from '../../actions/stats';
+import { getUser } from '../../actions/user';
+import { getGithubProjects } from '../../actions/projects';
+import GithubConnection from '../../components/Sidebar/GithubConnection';
+
+
+@injectIntl
+@withRouter
+@connect(
+  state => ({
+    user: getAuthenticatedUser(state),
+    draftPostsSC2: getDraftPostsSC2(state),
+    loading: getIsEditorLoading(state),
+    saving: getIsEditorSaving(state),
+    submitting: state.loading,
+  }),
+  {
+    createPost,
+    saveDraftSC2,
+    newPost,
+    notify,
+    getBeneficiaries,
+    getStats,
+    getUser,
+    getGithubProjects,
+  },
+)
+class WriteSC2 extends React.Component {
+  static propTypes = {
+    intl: PropTypes.shape().isRequired,
+    user: PropTypes.shape().isRequired,
+    draftPostsSC2: PropTypes.shape().isRequired,
+    loading: PropTypes.bool.isRequired,
+    saving: PropTypes.bool,
+    location: PropTypes.shape().isRequired,
+    newPost: PropTypes.func,
+    createPost: PropTypes.func,
+    saveDraftSC2: PropTypes.func,
+    notify: PropTypes.func,
+  };
+
+  static defaultProps = {
+    saving: false,
+    newPost: () => {},
+    createPost: () => {},
+    saveDraftSC2: () => {},
+    notify: () => {},
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      initialTitle: '',
+      initialTopics: [],
+      initialReward: '50',
+      initialType: '',
+      initialBody: '',
+      initialRepository: null,
+      initialPullRequests: [],
+      isUpdating: false,
+      warningModal: false,
+      parsedPostData: null,
+    };
+  }
+
+  componentDidMount() {
+    this.props.newPost();
+    const { draftPostsSC2, location: { search }, getUser, user, getGithubProjects } = this.props;
+    const draftId = new URLSearchParams(search).get('draft');
+    const draftPost = draftPostsSC2[draftId];
+
+    getUser(user.name).then((res) => {
+      if (res.response && res.response.github) {
+        getGithubProjects(user.name, true);
+      }
+    }); // @UTOPIAN INTERNAL DATA
+
+    if (draftPost) {
+      const { jsonMetadata, isUpdating } = draftPost;
+      let tags = [];
+      if (isArray(jsonMetadata.tags)) {
+        tags = jsonMetadata.tags;
+      }
+
+      if (draftPost.permlink) {
+        this.permlink = draftPost.permlink;
+      }
+
+      if (draftPost.originalBody) {
+        this.originalBody = draftPost.originalBody;
+      }
+
+      // eslint-disable-next-line
+      this.setState({
+        initialTitle: draftPost.title || '',
+        initialTopics: tags || [],
+        initialReward: draftPost.reward || '50',
+        initialType: jsonMetadata.type || 'ideas',
+        initialBody: draftPost.body || '',
+        isReviewed: draftPost.reviewed || false,
+        isUpdating: isUpdating || false,
+        initialRepository: jsonMetadata.repository,
+        initialPullRequests: jsonMetadata.pullRequests || [],
+      });
+    }
+  }
+
+  proceedSubmit = () => {
+    const { getBeneficiaries } = this.props;
+    const data = this.state.parsedPostData;
+    const { location: { search } } = this.props;
+    const id = new URLSearchParams(search).get('draft');
+    if (id) {
+      data.draftId = id;
+    };
+
+    this.setState({warningModal : false});
+
+    getBeneficiaries(data.author).then(res => {
+      if (res.response && res.response.results) {
+        const allBeneficiaries = res.response.results;
+        const beneficiaries = [
+          ...allBeneficiaries.map(beneficiary => {
+            let assignedWeight = 0;
+            if (beneficiary.vesting_shares) { // this is a sponsor
+              const sponsorSharesPercent = beneficiary.percentage_total_vesting_shares;
+              // 20% of all the rewards dedicated to sponsors
+              const sponsorsDedicatedWeight = 2000;
+              assignedWeight = Math.round((sponsorsDedicatedWeight * sponsorSharesPercent ) / 100);
+            } else {
+              // this is a moderator
+              const moderatorSharesPercent = beneficiary.percentage_total_rewards_moderators;
+              // 5% all the rewards dedicated to moderators
+              // This does not sum up. The total ever taken from an author is 20%
+              const moderatorsDedicatedWeight = 500;
+              assignedWeight = Math.round((moderatorsDedicatedWeight * moderatorSharesPercent ) / 100);
+            }
+
+            return {
+              account: beneficiary.account,
+              weight: assignedWeight || 1
+            }
+          })
+        ];
+
+        const extensions = [[0, {
+          beneficiaries
+        }]];
+
+        const contributionData = {
+          ...data,
+          extensions
+        };
+
+        console.log("CONTRIBUTION DATA", contributionData);
+
+        this.props.createPost(contributionData);
+
+      } else {
+        alert("Something went wrong. Please try again!")
+      }
+    });
+  };
+
+  onSubmit = (form) => {
+    const { getStats } = this.props;
+    const data = this.getNewPostData(form);
+    const { location: { search } } = this.props;
+    const id = new URLSearchParams(search).get('draft');
+    if (id) {
+      data.draftId = id;
+    };
+
+    this.setState({parsedPostData: data})
+
+    getStats()
+      .then(res => {
+        const { stats } = res.response;
+        const jsonData = data.jsonMetadata;
+        const categoryStats = stats.categories[jsonData.type];
+        const average_posts_length = categoryStats ? categoryStats.average_posts_length : 0;
+        const bodyLength = data.body.length;
+
+        if (bodyLength + 2000 < average_posts_length) {
+          this.setState({warningModal : true});
+        } else {
+          this.proceedSubmit();
+        }
+      })
+      .catch((e) => alert("Something went wrong. Please try again." + e))
+  };
+
+  getNewPostData = (form) => {
+    const data = {
+      body: form.body,
+      title: form.title,
+      reward: form.reward,
+    };
+
+    data.parentAuthor = '';
+    data.author = this.props.user.name || '';
+
+    const tags = [process.env.UTOPIAN_CATEGORY, ...form.topics];
+
+    const users = [];
+    const userRegex = /@([a-zA-Z.0-9-]+)/g;
+    const links = [];
+    const linkRegex = /\[.+?]\((.*?)\)/g;
+    const images = [];
+    const imageRegex = /!\[.+?]\((.*?)\)/g;
+    let matches;
+
+    const postBody = data.body;
+
+    // eslint-disable-next-line
+    while ((matches = userRegex.exec(postBody))) {
+      if (users.indexOf(matches[1]) === -1) {
+        users.push(matches[1]);
+      }
+    }
+
+    // eslint-disable-next-line
+    while ((matches = linkRegex.exec(postBody))) {
+      if (links.indexOf(matches[1]) === -1 && matches[1].search(/https?:\/\//) === 0) {
+        links.push(matches[1]);
+      }
+    }
+
+    // eslint-disable-next-line
+    while ((matches = imageRegex.exec(postBody))) {
+      if (images.indexOf(matches[1]) === -1 && matches[1].search(/https?:\/\//) === 0) {
+        images.push(matches[1]);
+      }
+    }
+
+    if (data.title && !this.permlink) {
+      data.permlink = kebabCase(data.title);
+    } else {
+      data.permlink = this.permlink;
+    }
+
+    if (this.state.isUpdating) data.isUpdating = this.state.isUpdating;
+
+    const metaData = {
+      community: 'utopian',
+      app: `utopian/${version}`,
+      format: 'markdown',
+      repository: form.repository,
+      pullRequests: form.pullRequests || [],
+      platform: 'github', // @TODO @UTOPIAN hardcoded
+      type: form.type,
+    };
+
+    if (tags.length) {
+      metaData.tags = tags;
+    }
+    if (users.length) {
+      metaData.users = users;
+    }
+    if (links.length) {
+      metaData.links = links;
+    }
+    if (images.length) {
+      metaData.image = images;
+    }
+
+    data.parentPermlink = process.env.UTOPIAN_CATEGORY; // @UTOPIAN forcing category
+    data.jsonMetadata = metaData;
+
+    if (this.originalBody) {
+      data.originalBody = this.originalBody;
+    }
+
+    return data;
+  };
+
+  handleImageInserted = (blob, callback, errorCallback) => {
+    const { formatMessage } = this.props.intl;
+    this.props.notify(
+      formatMessage({ id: 'notify_uploading_image', defaultMessage: 'Uploading image' }),
+      'info',
+    );
+    const formData = new FormData();
+    formData.append('files', blob);
+
+    fetch(`https://busy-img.herokuapp.com/@${this.props.user.name}/uploads`, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(res => res.json())
+      .then(res => callback(res.secure_url, blob.name))
+      .catch(() => {
+        errorCallback();
+        this.props.notify(
+          formatMessage({
+            id: 'notify_uploading_iamge_error',
+            defaultMessage: "Couldn't upload image",
+          }),
+        );
+      });
+  };
+
+  saveDraftSC2 = debounce((form) => {
+    const data = this.getNewPostData(form);
+    const postBody = data.body;
+    const { location: { search } } = this.props;
+    let id = new URLSearchParams(search).get('draft');
+
+    // Remove zero width space
+    const isBodyEmpty = postBody.replace(/[\u200B-\u200D\uFEFF]/g, '').trim().length === 0;
+
+    if (isBodyEmpty) return;
+
+    let redirect = false;
+
+    if (id === null) {
+      id = Date.now().toString(16);
+      redirect = true;
+    }
+
+    this.props.saveDraftSC2({ postData: data, id }, redirect);
+  }, 400);
+
+  render() {
+    const { initialTitle, initialTopics, initialType, initialBody, initialRepository, initialPullRequests, initialReward } = this.state;
+    const { loading, saving, submitting, user } = this.props;
+    const isSubmitting = submitting === Actions.CREATE_CONTRIBUTION_REQUEST || loading;
+
+    return (
+      <div className="shifted">
+        <div className="post-layout container">
+          <Affix className="rightContainer" stickPosition={77}>
+            <div className="right">
+              <GithubConnection user={user} />
+            </div>
+          </Affix>
+          <div className="center">
+            <Editor
+              ref={this.setForm}
+              saving={saving}
+              repository={initialRepository}
+              pullRequests={initialPullRequests}
+              title={initialTitle}
+              topics={initialTopics}
+              reward={initialReward}
+              type={initialType}
+              body={initialBody}
+              loading={isSubmitting}
+              isUpdating={this.state.isUpdating}
+              isReviewed={this.state.isReviewed}
+              onUpdate={this.saveDraftSC2}
+              onImageInserted={this.handleImageInserted}
+              user={user}
+              displayUpdateBtn={false}
+            />
+            <Modal
+              visible={this.state.warningModal}
+              title='Hey. Your Contribution may be better!'
+              okText={'Proceed anyways'}
+              cancelText='Keep editing'
+              onCancel={() => this.setState({warningModal: false})}
+              onOk={ () => {
+                  this.proceedSubmit();
+              }}
+            >
+              <p>
+                <Icon type="safety" style={{
+                  fontSize: '100px',
+                  color: 'red',
+                  display: 'block',
+                  clear: 'both',
+                  textAlign: 'center',
+                }}/>
+                <br />
+                Looking at the contribution you just wrote, seems like it less informative than others in this category.
+                <br /><br />
+                Please make sure you are adding <b>enough information</b> and that your contribution is <b>narrative and brings value</b>.
+                <br /><br />
+                Submitting the contribution as it is now, will either result in the <b>contribution being refused</b> by the Utopian Moderators or <b>lower votes/exposure</b>.
+              </p>
+            </Modal>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default WriteSC2;

--- a/src/post/Write/editorActions.js
+++ b/src/post/Write/editorActions.js
@@ -4,6 +4,7 @@ import SteemConnect from 'sc2-sdk';
 import { push } from 'react-router-redux';
 import { createAction } from 'redux-actions';
 import { addDraftLocaleStorage, deleteDraftLocaleStorage } from '../../helpers/localStorageHelpers';
+import { addDraftMetadata, deleteDraftMetadata } from '../../helpers/metadata';
 import { jsonParse } from '../../helpers/formatter';
 import { createPermlink, getBodyPatchIfSmaller } from '../../vendor/steemitHelpers';
 
@@ -54,6 +55,26 @@ export const saveDraft = (post, redirect) => dispatch =>
     meta: { postId: post.id },
   });
 
+export const saveDraftSC2 = (post, redirect) => dispatch =>
+  dispatch({
+    type: SAVE_DRAFT,
+    payload: {
+      promise: addDraftMetadata(post)
+        .then((resp) => {
+          if (redirect) {
+            if (post.projectId && post.type === 'task') {
+              dispatch(push(`/write-task-sc2/${post.projectId}/?draft=${post.id}`));
+            } else {
+              dispatch(push(`/write-sc2?draft=${post.id}`));
+            }
+          }
+          return resp;
+        }),
+    },
+    meta: { postId: post.id },
+  });
+
+
 export const deleteDraft = draftId => (dispatch) => {
   dispatch({
     type: DELETE_DRAFT,
@@ -63,6 +84,17 @@ export const deleteDraft = draftId => (dispatch) => {
     meta: { id: draftId },
   });
 };
+
+export const deleteDraftSC2 = draftId => (dispatch) => {
+  dispatch({
+    type: DELETE_DRAFT,
+    payload: {
+      promise: deleteDraftMetadata(draftId),
+    },
+    meta: { id: draftId },
+  });
+};
+
 
 export const editPost = post => (dispatch) => {
   const jsonMetadata = jsonParse(post.json_metadata);

--- a/src/post/Write/editorReducer.js
+++ b/src/post/Write/editorReducer.js
@@ -10,6 +10,8 @@ const defaultState = {
   saving: false,
   draftPosts: {},
   pendingDrafts: [],
+  draftPostsSC2: {},
+  pendingDraftsSC2: [],
   editedPosts: [],
 };
 
@@ -37,6 +39,7 @@ const editor = (state = defaultState, action) => {
       return {
         ...state,
         draftPosts: action.payload.drafts || defaultState.draftPosts,
+        draftPostsSC2: action.payload.user_metadata.drafts || defaultState.draftPostsSC2,
       };
     case editorActions.NEW_POST:
       return {
@@ -90,18 +93,24 @@ const editor = (state = defaultState, action) => {
           ...state.pendingDrafts,
           action.meta.id,
         ],
+        pendingDraftsSC2: [
+          ...state.pendingDraftsSC2,
+          action.meta.id,
+        ],
       };
     case editorActions.DELETE_DRAFT_SUCCESS: {
       return {
         ...state,
         draftPosts: action.payload,
         pendingDrafts: state.pendingDrafts.filter(id => id !== action.meta.id),
+        pendingDraftsSC2: state.pendingDraftsSC2.filter(id => id !== action.meta.id),
       };
     }
     case editorActions.DELETE_DRAFT_ERROR:
       return {
         ...state,
         pendingDrafts: state.pendingDrafts.filter(id => id !== action.meta.id),
+        pendingDraftsSC2: state.pendingDraftsSC2.filter(id => id !== action.meta.id),
       };
     case userActions.UPLOAD_FILE_START:
       return { ...state, loadingImg: true };
@@ -121,3 +130,7 @@ export const getIsEditorLoading = state => state.loading;
 export const getIsEditorSaving = state => state.saving;
 export const getPendingDrafts = state => state.pendingDrafts;
 export const getIsPostEdited = (state, permlink) => state.editedPosts.includes(permlink);
+
+export const getDraftPostsSC2 = state => state.draftPostsSC2;
+export const getPendingDraftsSC2 = state => state.pendingDraftsSC2;
+

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -68,9 +68,11 @@ export const getPostContent = (state, author, permlink) =>
 export const getPendingLikes = state => fromPosts.getPendingLikes(state.posts);
 
 export const getDraftPosts = state => fromEditor.getDraftPosts(state.editor);
+export const getDraftPostsSC2 = state => fromEditor.getDraftPostsSC2(state.editor);
 export const getIsEditorLoading = state => fromEditor.getIsEditorLoading(state.editor);
 export const getIsEditorSaving = state => fromEditor.getIsEditorSaving(state.editor);
 export const getPendingDrafts = state => fromEditor.getPendingDrafts(state.editor);
+export const getPendingDraftsSC2 = state => fromEditor.getPendingDraftsSC2(state.editor);
 export const getIsPostEdited = (state, permlink) =>
   fromEditor.getIsPostEdited(state.editor, permlink);
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -24,9 +24,11 @@ import Sponsors from './statics/Sponsors';
 import Moderators from './statics/Moderators';
 import Team from './statics/Team';
 import Write from './post/Write/Write';
+import WriteSC2 from './post/Write/WriteSC2';
 import WriteAnnouncement from './post/Write/WriteAnnouncement';
 
 import Drafts from './post/Write/Drafts';
+import DraftsSC2 from './post/Write/DraftsSC2';
 import RequireLogin from './auth/RequireLogin';
 
 export default (
@@ -70,6 +72,15 @@ export default (
       />
       <Route
         exact
+        path="/write-sc2"
+        render={() => (
+          <RequireLogin>
+            <WriteSC2 />
+          </RequireLogin>
+        )}
+      />
+      <Route
+        exact
         path="/write-task/:projectId"
         render={(props) => (
           <RequireLogin>
@@ -83,6 +94,15 @@ export default (
         render={() => (
           <RequireLogin>
             <Drafts />
+          </RequireLogin>
+        )}
+      />
+      <Route
+        exact
+        path="/drafts-sc2"
+        render={() => (
+          <RequireLogin>
+            <DraftsSC2 />
           </RequireLogin>
         )}
       />


### PR DESCRIPTION
Bug fix for issue raised in utopian.io.

[The Utopian Update Deleted my Draft](https://utopian.io/utopian-io/@st3llar/the-utopian-update-deleted-my-draft)

This provides the function to access old Steem Connect v2 drafts by accessing the URL `/drafts-sc2`

-        modified:   src/auth/authActions.js
-        modified:   src/components/Editor/Editor.js
-        new file:   src/post/Write/DraftRowSC2.js
-        new file:   src/post/Write/DraftsSC2.js
-        new file:   src/post/Write/WriteSC2.js
-        modified:   src/post/Write/editorActions.js
-        modified:   src/post/Write/editorReducer.js
-        modified:   src/reducers.js
-        modified:   src/routes.js
