### PR TITLE
Display similar contributions to the user

### DIFF
--- a/src/components/Sidebar/SimilarPosts.js
+++ b/src/components/Sidebar/SimilarPosts.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import debounce from 'lodash/debounce';
+
+import { getContributions } from '../../actions/contributions';
+
+import './SimilarPosts.less';
+
+@connect(
+  state => ({
+    contributions: state.contributions
+  }),
+  {
+    getContributions
+  }
+)
+class SimilarPosts extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      contributions: []
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.data !== nextProps.data && nextProps.data) {
+      const data = nextProps.data;
+      this.updateContributions(data.jsonMetadata.type, `${data.title}\n${data.body}`);
+    }
+  }
+
+  updateContributions = debounce((type, bySimilarity) => {
+    const { getContributions } = this.props;
+    getContributions({
+      limit: 5,
+      skip: 0,
+      section: 'all',
+      sortBy: 'created',
+      type,
+      bySimilarity,
+      reset: true
+    }).then(res => {
+      this.setState({
+        contributions: res.response.results
+      })
+    })
+  }, 1000);
+
+  render() {
+    return (
+      <div className="SimilarPosts">
+        <div className="SimilarPosts__container">
+          <h4 className="SimilarPosts__title">Found Similar Contributions</h4>
+          <div className="SimilarPosts__divider_bold"></div>
+          <ul>
+            {this.state.contributions.map(contrib => {
+              return (
+                <li key={contrib.permlink}>
+                  <a href={contrib.url} target="_blank">{contrib.title}</a>
+                  <div className="SimilarPosts__divider"></div>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default SimilarPosts;

--- a/src/components/Sidebar/SimilarPosts.less
+++ b/src/components/Sidebar/SimilarPosts.less
@@ -1,0 +1,38 @@
+@import (reference) "../../styles/custom.less";
+
+.SimilarPosts {
+  background: @white;
+  border: 1px solid #e9e7e7;
+  border-radius: @border-radius-base;
+  margin-bottom: 15px;
+  padding-bottom: 10px;
+  height: inherit;
+}
+
+.SimilarPosts__container {
+  padding: 8px 16px 16px 16px;
+  height: inherit;
+  overflow: auto;
+}
+
+.SimilarPosts__title {
+  color: #99aab5;
+  font-size: 18px;
+  font-weight: 500;
+
+  i { color: #444 }
+}
+
+.SimilarPosts__divider {
+  width: 100%;
+  height: 1px;
+  margin: 12px 0;
+  background-color: #e9e7e7;
+}
+
+.SimilarPosts__divider_bold {
+  width: 100%;
+  height: 1px;
+  margin: 12px 0;
+  background-color: #c9c8c8;
+}

--- a/src/post/Write/Write.js
+++ b/src/post/Write/Write.js
@@ -30,7 +30,7 @@ import { getStats } from '../../actions/stats';
 import { getUser } from '../../actions/user';
 import { getGithubProjects } from '../../actions/projects';
 import GithubConnection from '../../components/Sidebar/GithubConnection';
-
+import SimilarPosts from '../../components/Sidebar/SimilarPosts';
 
 @injectIntl
 @withRouter
@@ -328,8 +328,14 @@ class Write extends React.Component {
       });
   };
 
-  saveDraft = debounce((form) => {
-    const data = this.getNewPostData(form);
+  onUpdate = debounce(form => {
+    const data = this.getNewPostData(form)
+    this.setState({parsedPostData: data})
+    this.saveDraft()
+  }, 400);
+
+  saveDraft = () => {
+    const data = this.state.parsedPostData;
     const postBody = data.body;
     const { location: { search } } = this.props;
     let id = new URLSearchParams(search).get('draft');
@@ -347,10 +353,19 @@ class Write extends React.Component {
     }
 
     this.props.saveDraft({ postData: data, id }, redirect);
-  }, 400);
+  };
 
   render() {
-    const { initialTitle, initialTopics, initialType, initialBody, initialRepository, initialPullRequests, initialReward } = this.state;
+    const {
+      initialTitle,
+      initialTopics,
+      initialType,
+      initialBody,
+      initialRepository,
+      initialPullRequests,
+      initialReward,
+      parsedPostData
+     } = this.state;
     const { loading, saving, submitting, user } = this.props;
     const isSubmitting = submitting === Actions.CREATE_CONTRIBUTION_REQUEST || loading;
 
@@ -360,6 +375,7 @@ class Write extends React.Component {
           <Affix className="rightContainer" stickPosition={77}>
             <div className="right">
               <GithubConnection user={user} />
+              <SimilarPosts data={parsedPostData} />
             </div>
           </Affix>
           <div className="center">
@@ -376,7 +392,7 @@ class Write extends React.Component {
               loading={isSubmitting}
               isUpdating={this.state.isUpdating}
               isReviewed={this.state.isReviewed}
-              onUpdate={this.saveDraft}
+              onUpdate={this.onUpdate}
               onSubmit={this.onSubmit}
               onImageInserted={this.handleImageInserted}
               user={user}


### PR DESCRIPTION
By displaying similar contributions in the side bar, users will have an easier time avoiding duplicate contribution submissions. Thereby helping free up a moderator's time as well. The look up works exactly the same way that search does, including title and body, displaying the top results.

![](https://res.cloudinary.com/hpiynhbhq/image/upload/v1510721907/skbjcxnembm5qdvzlxs1.gif)

## Development

A `SimilarPosts` React component was created that carries the necessary functionality of handling the API call. It uses a `data` prop that contains the fields necessary to start the search. The same API endpoint as searching is used when invoking the API call. This ensures that the same results are received as you would from searching. The results are stored in a state and then displayed to the user.

Adjusting what data gets returned is easy to do within the created React component. An `updateContributions` function gets invoked with a debounce to prevent server spam with constant requests. The query happens inside of that functions and sets the state for the results to be displayed.