### PR TITLE
Fixed floating search combobox

### DIFF
--- a/src/components/Navigation/Topnav.less
+++ b/src/components/Navigation/Topnav.less
@@ -2,10 +2,15 @@
 
 @base-spacing: 0;
 
-.ant-select-dropdown-menu-item {
-  .anticon-github {
-    font-size: 16px;
-    color: #444;
+.ant-select-dropdown {
+  position: fixed !important;
+  top:56px !important;
+
+  &-menu-item {
+    .anticon-github {
+      font-size: 16px;
+      color: #444;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #95.

Changes I made:
- forced with `!important`the search combobox (`.ant-select-dropdown`) to have position fixed (like the top nav) so that it will not scroll with the rest of the content.