### PR TITLE
Fixes tooltip over modal and floating combobox issues

### DIFF
--- a/src/components/Navigation/Topnav.less
+++ b/src/components/Navigation/Topnav.less
@@ -2,10 +2,15 @@
 
 @base-spacing: 0;
 
-.ant-select-dropdown-menu-item {
-  .anticon-github {
-    font-size: 16px;
-    color: #444;
+.ant-select-dropdown {
+  position: fixed !important;
+  top:56px !important;
+
+  &-menu-item {
+    .anticon-github {
+      font-size: 16px;
+      color: #444;
+    }
   }
 }
 

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -28,8 +28,12 @@ body {
   overflow: hidden;
 }
 
-.ant-tooltip-content {
-  font-weight: 500;
+.ant-tooltip {
+  z-index: 999;
+
+  &-content {
+    font-weight: 500;
+  }
 }
 
 .ant-popover-title {


### PR DESCRIPTION
Fixes #95, #98 

Changes I made for #95:
- forced with `!important` the search combobox (`.ant-select-dropdown`) to have position fixed (like the top nav) so that it will not scroll with the rest of the content.

Changes I made for #98:
- set a lower `z-index` for `.ant-select-dropdown` so that the vote's tooltip will always be under the vote's modal

