### PR TITLE
Strengthen README.md with Local Installation Directions, more information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Originally forked from https://github.com/busyorg/busy.git, Utopian wants to reward Open Source contributors for their hard work.
+Originally forked from https://github.com/busyorg/busy.git, [Utopian](https://utopian.io) wants to reward Open Source contributors for their hard work. See the website in action [here.](https://utopian.io)
 
 ## Contributing
 1. Get in touch on Discord: https://discord.gg/5qMzAJ
@@ -19,6 +19,9 @@ These commands may take a while to process, because it needs to download everyth
 
 ![](https://steemitimages.com/DQmaaMZtej1YsQYrFXZh3qTLKgCXNTiFYhUb6U2UT4yyb7c/image.png)
 
-Utopian is now running on your machine! To access the local website, use any browser and go to `localhost:3000/` (or whatever Terminal says next to "Project is running at".)
+Utopian is now running on your machine! 
+* To access the local website, use any browser and go to `localhost:3000/` (or whatever Terminal says next to "Project is running at".)
+* To make a code change, use any editor to change any file in the code locally. If you change a `.js` file, the `webpack` will probably _automatically_ update itself and reload any browser pages that are viewing your local snapshot.
+* When submitting a pull request, make sure to uncheck/delete the original `webpack-dev-server.js` code change, as that's only used for running the project locally.
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-Originally forked from https://github.com/busyorg/busy.git, [Utopian](https://utopian.io) wants to reward Open Source contributors for their hard work. See the website in action [here.](https://utopian.io)
+[Utopian.io](https://utopian.io) wants to reward Open Source contributors for their hard work. 
+Forked from https://github.com/busyorg/busy, Utopian uses the [STEEM Blockchain](https://steem.io) to reward contributors in cryptocurrency.
 
-## Contributing
+See the website in action [here:](https://utopian.io)
+
+<center><img src="https://steemitimages.com/DQmTdu5ndWC2s1NwdYftLzc4oYhqCrowWqMHE2Q92c93W9F/image.png"/></center>
+  
+## Contributing to this Project
 1. Get in touch on Discord: https://discord.gg/5qMzAJ
 2. Clone this repository locally on your computer. If you don't have `git` installed, simply pressing the "Download ZIP" button and unzipping the file should work.
 3. **Locally**, go to the `webpack/webpack-dev-server.js` file. Change the line that begins with `UTOPIAN_API` to this:
@@ -23,5 +28,8 @@ Utopian is now running on your machine!
 * To access the local website, use any browser and go to `localhost:3000/` (or whatever Terminal says next to "Project is running at".)
 * To make a code change, use any editor to change any file in the code locally. If you change a `.js` file, the `webpack` will probably _automatically_ update itself and reload any browser pages that are viewing your local snapshot.
 * When submitting a pull request, make sure to uncheck/delete the original `webpack-dev-server.js` code change, as that's only used for running the project locally.
+
+#### API Server
+Our sister project [utopian-io/api.utopian.io](https://github.com/utopian-io/api.utopian.io) provides the back-end APIs for Utopian. If you want to run Utopian locally, you **do not** need to run that project, though you may want to check it out anyways!
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
 Originally forked from https://github.com/busyorg/busy.git, Utopian wants to reward Open Source contributors for their hard work.
 
 ## Contributing
-Get in touch on Discord: https://discord.gg/5qMzAJ
+1. Get in touch on Discord: https://discord.gg/5qMzAJ
+2. Clone this repository locally on your computer. If you don't have `git` installed, simply pressing the "Download ZIP" button and unzipping the file should work.
+3. **Locally**, go to the `webpack/webpack-dev-server.js` file. Change the line that begins with `UTOPIAN_API` to this:
+```javascript
+UTOPIAN_API: JSON.stringify(process.env.UTOPIAN_API || 'https://api.utopian.io/api/'),
+```
+Remember not to push this change to the repository in your commits/pull requests.
 
+4. Use Terminal or your Command Prompt and change the directory to the `utopian.io` directory (`cd`). 
+5. Once you're inside the `utopian.io` directory in Terminal, run these commands:
+```bash
+npm install
+npm run dev-server
+```
+These commands may take a while to process, because it needs to download everything necessary to start Utopian. Once it's done, wait for text like this:
+
+![](https://steemitimages.com/DQmaaMZtej1YsQYrFXZh3qTLKgCXNTiFYhUb6U2UT4yyb7c/image.png)
+
+Utopian is now running on your machine! To access the local website, use any browser and go to `localhost:3000/` (or whatever Terminal says next to "Project is running at".)
 ## License
 MIT


### PR DESCRIPTION
The `README.md` is the first thing Github users see when they view this repository, and if it's as dry and useless as it is right now, it doesn't seem inviting for others to contribute.

I've added:
* better descriptions
* screenshots
* information on running Utopian locally
* info on API Server

and more, to make sure everyone knows how to contribute to Utopian.