### PR TITLE
Fixed webpack 'probably' recompiling on change

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ These commands may take a while to process, because it needs to download everyth
 
 Utopian is now running on your machine! 
 * To access the local website, use any browser and go to `localhost:3000/` (or whatever Terminal says next to "Project is running at".)
-* To make a code change, use any editor to change any file in the code locally. If you change a `.js` file, the `webpack` will probably _automatically_ update itself and reload any browser pages that are viewing your local snapshot.
+* To make a code change, use any editor to change any file in the code locally. If you change a `.js` file, the `webpack` will _automatically_ update itself and reload any browser pages that are viewing your local snapshot.
 * When submitting a pull request, make sure to uncheck/delete the original `webpack-dev-server.js` code change, as that's only used for running the project locally.
 
 #### API Server

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "dev-server": "run-p dev-server:auth-server dev-server:client",
-    "dev-server:client": "webpack-dev-server --config ./webpack/webpack-dev-server.js",
+    "dev-server:client": "webpack-dev-server --watch-poll --config ./webpack/webpack-dev-server.js",
     "dev-server:auth-server": "node ./server/auth-server.js",
     "start": "cross-env NODE_ENV=production npm run run:server",
     "dev": "cross-env NODE_ENV=development run-p build:server:dev run:server",


### PR DESCRIPTION
Quote from readme
> If you change a `.js` file, the `webpack` will probably _automatically_ update itself

This change fixed the **probably** part for me. Can you check if it becomes consistent after this change and if so merge it?