### PR TITLE
Fixed regex pattern in webpack configs not matching *.less files

### DIFF
--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -113,7 +113,7 @@ function makeStyleLoaders(options) {
   if (options.isDevelopment) {
     return [
       {
-        test: /\.css|.less$/,
+        test: /\.(css|less)$/,
         use: [
           {
             loader: 'style-loader',
@@ -136,7 +136,7 @@ function makeStyleLoaders(options) {
 
   return [
     {
-      test: /\.css|.less$/,
+      test: /\.(css|less)$/,
       loader: ExtractTextPlugin.extract({
         //fallback: 'style-loader',
         use: [

--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -49,7 +49,7 @@ module.exports = {
         loader: 'url-loader',
       },
       {
-        test: /\.css|.less$/,
+        test: /\.(css|less)$/,
         use: [
           'style-loader',
           'css-loader',

--- a/webpack/webpack.server.config.js
+++ b/webpack/webpack.server.config.js
@@ -63,7 +63,7 @@ module.exports = {
         },
       },
       {
-        test: /\.css|.less$/,
+        test: /\.(css|less)$/,
         use: [
           'isomorphic-style-loader',
           'css-loader',


### PR DESCRIPTION
So editing a *.less file will now auto compile properly.

Note that dot (.) wasn't escaped via backslash in old version. That was the problem.