### PR TITLE
Fix bug when loading GitHub repos

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -80,9 +80,8 @@ export default class Wrapper extends React.PureComponent {
       this.setState({loadingRepos: true});
       getUser(user.name).then(res => {
         if (res.response && res.response.github) {
-          getReposByGithub(user.name, true).then( () => {
-            this.setState({loadedRepos: true, loadingRepos: false});
-          })
+          this.setState({loadedRepos: true, loadingRepos: false});
+          getReposByGithub(user.name, true);
         }else{
           this.setState({loadedRepos: true, loadingRepos: false});
         }


### PR DESCRIPTION
This PR fixes the issue with the GitHub token. When the GitHub token expires, the frontend freezes because it depends on the `repos` endpoint that doesn't return anything.

To fix it, I changed the frontend to load the page, even if the user's repos are not loaded yet.