### PR TITLE
changing search type now filters posts also

### DIFF
--- a/src/components/Navigation/Topnav.js
+++ b/src/components/Navigation/Topnav.js
@@ -49,10 +49,16 @@ class Topnav extends React.Component {
     return false;
   };
 
+  handleChangeSearchType(section) {
+    this.setState({ searchSection: section })
+    this.props.history.push(`/search/${section}`);    
+  }
+
   constructor (props) {
     super(props)
     this.renderItems = this.renderItems.bind(this);
     this.searchSelected = this.searchSelected.bind(this);
+    this.handleChangeSearchType = this.handleChangeSearchType.bind(this);
     this.state = {
       searchSection: this.searchSelected(props.location) || 'projects',
     };
@@ -68,8 +74,8 @@ class Topnav extends React.Component {
     return (
       <div className="Search">
 
-        <InputGroup compact>
-          <Select defaultValue={this.searchSelected(location) || 'projects'} onChange={(section) => this.setState({searchSection: section})}>
+        <InputGroup compact>                                                
+          <Select defaultValue={this.searchSelected(location) || 'projects'} onChange={this.handleChangeSearchType}>
             <Option value="projects"><Icon type="github" className="iconfont icon-search" /> Projects</Option>
             <Option value="ideas"><CategoryIcon type="ideas"/> Suggestions</Option>
             <Option value="sub-projects"><CategoryIcon type="sub-projects"/> Sub-Projects</Option>

--- a/src/components/Navigation/Topnav.js
+++ b/src/components/Navigation/Topnav.js
@@ -50,8 +50,27 @@ class Topnav extends React.Component {
   };
 
   handleChangeSearchType(section) {
+    const { history } = this.props
     this.setState({ searchSection: section })
-    this.props.history.push(`/search/${section}`);    
+
+    const validPaths = [
+      'projects',
+      'ideas',
+      'development',
+      'bug-hunting',
+      'translations',
+      'graphics',
+      'documentation',
+      'analysis',
+      'social',
+      'blog',
+      ''
+    ]
+    // Only change path if we are on a 1st level url of one of the valid paths
+    if (validPaths.includes(history.location.pathname.substring(1))
+      && history.location.pathname.split('/').length != 1) {
+      history.push(`/${section}`);
+    }
   }
 
   constructor (props) {

--- a/src/feed/SubFeed.js
+++ b/src/feed/SubFeed.js
@@ -230,7 +230,7 @@ class SubFeed extends React.Component {
       <div>
         <ScrollToTop />
         {((match.path !== "/@:name" && match.params.type !== 'blog') || (match.params.type === 'blog' && this.isModerator() && match.params.filterBy === 'review') && ((match.path !== '/tasks' && !this.isTask()) || ((match.path == '/tasks' || (this.isTask())) && this.isModerator() && match.params.filterBy === 'review'))) && !((match.path === '/tasks' || (this.isTask() && match.params.filterBy !== 'review'))) ?
-          <Tabs defaultActiveKey={match.params.type || 'all'} onTabClick={type => goTo(`${type}`)}>
+          <Tabs activeKey={match.params.type || 'all'} onTabClick={type => goTo(`${type}`)}>
             {this.isModerator() && match.params.filterBy === 'review' ? <TabPane tab={<span><Icon type="safety" />Pending Review</span>} key="pending" /> : null}
             <TabPane tab={<span><Icon type="appstore-o" />All</span>} key="all" />
             {this.isModerator() && match.params.filterBy === 'review'? <TabPane tab={<span><Icon type="paper-clip" />Blog Posts</span>} key="blog" /> : null}
@@ -251,7 +251,7 @@ class SubFeed extends React.Component {
           </Tabs> : null}
 
         {(match.path === '/tasks' || (this.isTask() && match.params.filterBy !== 'review')) ?
-          <Tabs defaultActiveKey={match.params.type || 'all'} onTabClick={type => goTo(`${type}`)}>
+          <Tabs activeKey={match.params.type || 'all'} onTabClick={type => goTo(`${type}`)}>
             {/*<TabPane tab={<span><Icon type="appstore-o" />All</span>} key="tasks" />*/}
             <TabPane tab={<span><Icon type="notification" />Tasks Requests</span>} key="tasks" />
             <TabPane tab={<span><CategoryIcon type="task-ideas" />Thinkers</span>} key="task-ideas" />


### PR DESCRIPTION
- Closes #193: Dropdown menu not functioning properly
- Now when changing the search type it also filters the posts
- Only changes the path when on a valid path (home page or other filters)
- This will not change the path if you are currently writing a post or on any other invalid paths, it will only change the search type like normal
![out](https://user-images.githubusercontent.com/9692067/33753000-14079a36-dbb3-11e7-8db8-5ef1975ce4bf.gif)

