### PR TITLE
Fix invalid uri characters

### DIFF
--- a/src/components/Navigation/Topnav.js
+++ b/src/components/Navigation/Topnav.js
@@ -72,11 +72,25 @@ class Topnav extends React.Component {
     }
   }
 
+  handleChangeSearch(event) {
+    const { history } = this.props
+    const { searchSection } = this.state
+    
+    // Replace invalid URI characters with empty string
+    const query = event.target.value.replace(/[@#%*]/g, '')
+
+    // Search when hitting enter and not empty string
+    if (query && event.key === 'Enter') {
+      history.push(`/search/${searchSection}/${query}`);
+    }
+  }
+
   constructor (props) {
     super(props)
     this.renderItems = this.renderItems.bind(this);
     this.searchSelected = this.searchSelected.bind(this);
     this.handleChangeSearchType = this.handleChangeSearchType.bind(this);
+    this.handleChangeSearch = this.handleChangeSearch.bind(this);
     this.state = {
       searchSection: this.searchSelected(props.location) || 'projects',
     };
@@ -112,14 +126,7 @@ class Topnav extends React.Component {
           <Input
             ref={input => this.searchInput = input}
             placeholder="Search..."
-            onKeyPress={(event) => {
-              const q = event.target.value;
-              const searchSection = this.state.searchSection;
-
-              if (event.key === 'Enter') {
-                history.push(`/search/${searchSection}/${q}`);
-              }
-            }}
+            onKeyPress={this.handleChangeSearch}
           />
         </InputGroup>
 
@@ -161,37 +168,8 @@ class Topnav extends React.Component {
             <Menu.Item key="user" className="Topnav__item-user">
               <Link className="Topnav__user" to={`/@${username}`}>
                 <Avatar username={username} size={36}/>
-                {/*<span className="Topnav__user__username">
-                 {username}
-                 </span>*/}
               </Link>
             </Menu.Item>
-            {/*<Menu.Item
-             key="notifications"
-             className="Topnav__item--badge"
-             >
-             <Tooltip placement="bottom"
-             title={intl.formatMessage({id: 'notifications', defaultMessage: 'Notifications'})}>
-             <Popover
-             placement="bottomRight"
-             trigger="click"
-             content={
-             <Notifications
-             notifications={notifications}
-             onClick={onNotificationClick}
-             onSeeAllClick={onSeeAllClick}
-             />
-             }
-             title={intl.formatMessage({id: 'notifications', defaultMessage: 'Notifications'})}
-             >
-             <a className="Topnav__link Topnav__link--light">
-             <Badge count={notificationsCount}>
-             <i className="iconfont icon-remind"/>
-             </Badge>
-             </a>
-             </Popover>
-             </Tooltip>
-             </Menu.Item>*/}
             <Menu.Item key="more">
               <Popover
                 placement="bottom"

--- a/src/components/Story/Story.js
+++ b/src/components/Story/Story.js
@@ -93,6 +93,7 @@ class Story extends React.Component {
       sliderMode,
       defaultVotePercent,
       onLikeClick,
+      onEditClick,
       onShareClick,
     } = this.props;
 
@@ -275,6 +276,7 @@ class Story extends React.Component {
               sliderMode={sliderMode}
               defaultVotePercent={defaultVotePercent}
               onLikeClick={onLikeClick}
+              onEditClick={onEditClick}
               onShareClick={onShareClick}
             />}
           </div>

--- a/src/components/Story/Story.js
+++ b/src/components/Story/Story.js
@@ -93,7 +93,6 @@ class Story extends React.Component {
       sliderMode,
       defaultVotePercent,
       onLikeClick,
-      onEditClick,
       onShareClick,
     } = this.props;
 
@@ -276,7 +275,6 @@ class Story extends React.Component {
               sliderMode={sliderMode}
               defaultVotePercent={defaultVotePercent}
               onLikeClick={onLikeClick}
-              onEditClick={onEditClick}
               onShareClick={onShareClick}
             />}
           </div>


### PR DESCRIPTION
- Fixes #211: Inclusion of the `%` symbol in the search bar causes errors
- Removed `@, #, %, and *` from any search queries
- Slightly cleaned up unused code

Demonstration below, look at the url to see `utopian.io` vs. `localhost`
![out](https://user-images.githubusercontent.com/9692067/34067730-dbdafe42-e1fb-11e7-92ba-d8afa1446898.gif)
