### PR TITLE
Update rules

### DIFF
--- a/src/components/Editor/EditorAnnouncement.js
+++ b/src/components/Editor/EditorAnnouncement.js
@@ -535,7 +535,7 @@ class EditorAnnouncement extends React.Component {
                 <li>You must provide exactly what you are looking and how would you like it to be in great details.</li>
                 <li>Whether you are looking for a logo, layout, banner or similar, your request has to be very specific.</li>
               </ul>
-              <p>Not respecting the rules will either give you lower votes or your announcemnt won't be accepted.</p>
+              <p>Not respecting the rules will either give you lower votes or your announcement won't be accepted.</p>
               <AcceptRules />
             </div>
           )

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -56,6 +56,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
           {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>Only merged Pull Requests will be accepted or Open Source projects you maintain never posted on Utopian before, forks included as long as the fork is not just a mirror of the original one. Proof of work required.</li>
+            <li>The contribution will be rejected if the Pull Request wasn't merged within the last 30 days.</li>
             <li>In this category you can only write if you have developed or contributed to the development.</li>
             <li>You must provide the links to the branches/forks/gists/pull requests.</li>
             <li>If your username on Github does not correspond to the Utopian username you must provide proof you are the owner by providing a screenshot of the logged in session in Github.</li>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -169,6 +169,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
             <li>This category is meant only for providing results of <b>online social engagement</b>, adv and similar for an Open Source project.</li>
             <li>You must include links and proofs of the visibility effort you made and write down the results.</li>
             <li>If your effort brought 0 or very little new users/contributors to the Open Source project you are invited to not write about it.</li>
+            <li>Moderator may reject the contribution if they believe that there are not enough results for the contribution to be rewarded.</li>
             <li>You must proof of your effort. If your Utopian username does not correspond to the username used in the platforms for advertising the project, you must provide screenshots of the logged in session in these platforms. </li>
             <li>Never write about visibility efforts you have already shared before.</li>
           </ul>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -109,7 +109,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
           <h2><CategoryIcon from="from-rules"  type="translations"/> Translations Rules</h2>
           {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
-            <li><b>Minimum 500 words per translation contribution. Text that is supposed to remain untranslated (links, code, paths, ...) or duplicated strings/text can't be included in the minimum. Strings that are repeated in the project and the translation is the same for more than one string can be counted only once since they are supposed to have the same translation.</b></li>
+            <li><b>Minimum 500 words per translation contribution. Text that is supposed to remain untranslated (links, code, paths, ...) or duplicated strings/text can't be included in the minimum.</b></li>
             <li>You could translate less than 500 words if the project itself has less than 500 words to be translated in total.</li>
             <li>Only translations on CrowdIn or Github are accepted. You should not translate the words and provide them in your Utopian post directly.</li>
             <li>This category is meant only for translations you have updated or created for an Open Source project.</li>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -117,6 +117,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
             <li>You must be the author of the translation and provide a way to verify your work.</li>
             <li>If your username on CrowdIn or similar translation platforms does not correspond to the Utopian username you must provide proof you are the owner by providing a screenshot of the logged in session in the translation platform.</li>
             <li>Same translations from different authors will be accepted if the moderator can recognise the newest translation has better quality.</li>
+            <li>If the provided translation is obviously machine-translated, the contribution will be rejected.</li>
             <li>Proof-reading is not acceptable in Utopian at the moment. This is temporary. Soon proof-reading will be accepted as a valid contribution.</li>
           </ul>
           <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -56,6 +56,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
           {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>Only merged Pull Requests will be accepted or Open Source projects you maintain never posted on Utopian before, forks included as long as the fork is not just a mirror of the original one. Proof of work required.</li>
+            <li>Projects must have a README file for installation and usage.</li>
             <li>The contribution will be rejected if the Pull Request wasn't merged within the last 30 days.</li>
             <li>In this category you can only write if you have developed or contributed to the development.</li>
             <li>You must provide the links to the branches/forks/gists/pull requests.</li>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -109,7 +109,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
           <h2><CategoryIcon from="from-rules"  type="translations"/> Translations Rules</h2>
           {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
-            <li><b>Minimum 500 words per translation contribution. Text that is supposed to remain untranslated (links, code, paths, ...) or duplicated strings/text can't be included in the minimum.</b></li>
+            <li><b>Minimum 500 words per translation contribution. Text that is supposed to remain untranslated (links, code, paths, ...) or duplicated strings/text can't be included in the minimum. Strings that are repeated in the project and the translation is the same for more than one string can be counted only once since they are supposed to have the same translation.</b></li>
             <li>You could translate less than 500 words if the project itself has less than 500 words to be translated in total.</li>
             <li>Only translations on CrowdIn or Github are accepted. You should not translate the words and provide them in your Utopian post directly.</li>
             <li>This category is meant only for translations you have updated or created for an Open Source project.</li>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -109,7 +109,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
           <h2><CategoryIcon from="from-rules"  type="translations"/> Translations Rules</h2>
           {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
-            <li><b>Minimum 500 words per translation contribution.</b></li>
+            <li><b>Minimum 500 words per translation contribution. Text that is supposed to remain untranslated (links, code, paths, ...) or duplicated strings/text can't be included in the minimum.</b></li>
             <li>You could translate less than 500 words if the project itself has less than 500 words to be translated in total.</li>
             <li>Only translations on CrowdIn or Github are accepted. You should not translate the words and provide them in your Utopian post directly.</li>
             <li>This category is meant only for translations you have updated or created for an Open Source project.</li>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -134,8 +134,9 @@ export const Rules = ({type, acceptRules, inEditor}) => {
             <li>You must provide samples of your creations directly on this post and include public links to the full design.</li>
             <li>This category is meant only for graphics/videos/motion graphics you have realised for an Open Source project.</li>
             <li>You must include every possible detail to verify the work done.</li>
-            <li>You must provide the editable files, as PSD and similar source files.</li>
+            <li>You must provide the editable files, as PSD and similar source files. Flatten and rasterized layers are not editable.</li>
             <li>If you are providing a logo, you should also provide the different logo variations in terms of sizes and colors and also compare the new logo with the previous one, when applicable.</li>
+            <li>Logo designs must be in a vector format unless the project owner specifies a different format.</li>
             <li>T-shirts and merchandising in general are not welcome unless explicitly requested by the project owner.</li>
             <li>Never post about graphics you have already shared before.</li>
           </ul>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -73,7 +73,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
           <h2><CategoryIcon from="from-rules"  type="blog"/> Blog Post Rules</h2>
           {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
-            <li>You must provide an original format/s. You can't post about news found in the web or general thoughts, unless you have a unique and consistent format. <a href="https://utopian.io/utopian-io/@utopian-io/2xqdoa-utopian-weekly-1-the-weekly-open-source-newsletter">Example of a good format</a>.</li>
+            <li>You must provide an original and a unique editorial content of very high quality that is strongly related to the promotion and development of open-source related projects. Blogs must have a unique and consistent format. <a href="https://utopian.io/utopian-io/@utopian-io/2xqdoa-utopian-weekly-1-the-weekly-open-source-newsletter">Example of a good format</a>.</li>
             <li>You may only write blog posts that are related to the promotion, development and functions of open-source projects.</li>
             <li>Blog posts must provide detailed content and overviews related to the open-source projects.</li>
             <li>Images, screenshots, links and examples are not necessary but preferred.</li>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -58,7 +58,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
             <li>Only merged Pull Requests will be accepted or Open Source projects you maintain never posted on Utopian before, forks included as long as the fork is not just a mirror of the original one. Proof of work required.</li>
             <li>Projects must have a README file for installation and usage.</li>
             <li>The contribution will be rejected if the Pull Request wasn't merged within the last 30 days.</li>
-            <li>In this category you can only write if you have developed or contributed to the development.</li>
+            <li>In this category you can only write if you have developed or contributed to the development. Simple and common code snippets can't be submitted in the development category.</li>
             <li>You must provide the links to the branches/forks/gists/pull requests.</li>
             <li>If your username on Github does not correspond to the Utopian username you must provide proof you are the owner by providing a screenshot of the logged in session in Github.</li>
             <li>Images, screenshots, links and examples are not necessary but preferred.</li>

--- a/src/statics/Rules.js
+++ b/src/statics/Rules.js
@@ -117,6 +117,8 @@ export default (props) =>
         Additionally, moderators reserve the right to apply temporal or permanent bans who have shown a history of consistently disobeying the rules. <br/>
         </p>
       <p>Every moderator works on a specified set of categories and is assigned to one supervisor. You can see the spreadsheet with the moderators teams <a href="https://docs.google.com/spreadsheets/d/11AqLQPgULU4F7fIwfArqYdAcexufSH3IBEY32yVVm4I">here</a></p>
+      <h2>Utopian bot</h2>
+      <p>Utopian can unvote the contribution if it is found out that the contribution did not meet the rules and had been upvoted by mistake. This decision considers cases such as attempts of plagiarism, copying work and ideas of others or other violation of the rules which would be obvious to see that the contribution does not deserve the reward.</p>
       <h2>Categories Specific Rules</h2>
       <br />
       <Rules inEditor={false} type="ideas" />

--- a/src/statics/Rules.js
+++ b/src/statics/Rules.js
@@ -116,6 +116,7 @@ export default (props) =>
       <p>For contributors, remember that Utopian Moderators reserve the right to a) verify acceptable posts, b) deliberate and review pending posts, and c) flag/hide posts that do not follow the rules or posts that are of very low quality.
         Additionally, moderators reserve the right to apply temporal or permanent bans who have shown a history of consistently disobeying the rules. <br/>
         </p>
+      <p>Every moderator is working on a specified set of categories and is assigned to one superivosor. You can see the spreadsheet with the moderators teams <a href="https://docs.google.com/spreadsheets/d/11AqLQPgULU4F7fIwfArqYdAcexufSH3IBEY32yVVm4I">here</a></p>
       <h2>Categories Specific Rules</h2>
       <br />
       <Rules inEditor={false} type="ideas" />

--- a/src/statics/Rules.js
+++ b/src/statics/Rules.js
@@ -113,7 +113,7 @@ export default (props) =>
       <h2>Moderators</h2>
       <p>For moderators, check <em><a href="https://utopian.io/welcome-moderator">Welcome Moderator</a></em> for guidelines on how to effectively moderate on Utopian.</p><br/>
       <p>A moderator should always give at least one opportunity to fix/edit a post, and never reject and hide it on the first sight.</p>
-      <p>For contributors, remember that Utopian Moderators reserve the right to a) verify acceptable posts, b) deliberate and review pending posts, and c) flag/hide posts that do not follow the rules.
+      <p>For contributors, remember that Utopian Moderators reserve the right to a) verify acceptable posts, b) deliberate and review pending posts, and c) flag/hide posts that do not follow the rules or posts that are of very low quality.
         Additionally, moderators reserve the right to apply temporal or permanent bans who have shown a history of consistently disobeying the rules. <br/>
         </p>
       <h2>Categories Specific Rules</h2>

--- a/src/statics/Rules.js
+++ b/src/statics/Rules.js
@@ -116,7 +116,7 @@ export default (props) =>
       <p>For contributors, remember that Utopian Moderators reserve the right to a) verify acceptable posts, b) deliberate and review pending posts, and c) flag/hide posts that do not follow the rules or posts that are of very low quality.
         Additionally, moderators reserve the right to apply temporal or permanent bans who have shown a history of consistently disobeying the rules. <br/>
         </p>
-      <p>Every moderator is working on a specified set of categories and is assigned to one superivosor. You can see the spreadsheet with the moderators teams <a href="https://docs.google.com/spreadsheets/d/11AqLQPgULU4F7fIwfArqYdAcexufSH3IBEY32yVVm4I">here</a></p>
+      <p>Every moderator works on a specified set of categories and is assigned to one supervisor. You can see the spreadsheet with the moderators teams <a href="https://docs.google.com/spreadsheets/d/11AqLQPgULU4F7fIwfArqYdAcexufSH3IBEY32yVVm4I">here</a></p>
       <h2>Categories Specific Rules</h2>
       <br />
       <Rules inEditor={false} type="ideas" />

--- a/src/statics/Rules.js
+++ b/src/statics/Rules.js
@@ -76,7 +76,7 @@ export default (props) =>
       <h2>Contributions should be in English</h2>
       Contributions should be in plain English and fully understandable. The only accepted exceptions are:
       <ul>
-        <li>Contributions under the Tutorials and Video Tutorials Category.</li>
+        <li>Contributions under the Tutorials and Video Tutorials Category, and Blog posts.</li>
         <li>Open Source projects that are meant to be for specific languages only.</li>
       </ul>
       <br />


### PR DESCRIPTION
Rules update according to the poll results. There are some points that are more of implementation in the Utopian interface than regular rules.

- Q-12378 We should make a whitelist of languages we can accept based on languages moderators can understand. This list should grow over time.
  - This one can be included when the list is made.
- Q-12380 In the blog category contributors should be forced to pick a github repository to link the blog post to a specific Open Source project.
  - blogs must have selected repositories the same way as contributions
- Q-12381 We should make a repos blacklists. Every contribution under these repositories will be rejected.
  - The blacklist is not created yet. Manual check if the repository is blacklisted is not sustainable.
- Q-12381 Supervisors should have a weekly voice conference with the moderators. Each team will make a public review in this voice session.
  - Is this needed to be put in the rules?
