### PR TITLE
 Fix of estimated upvote amount bug

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -12,7 +12,7 @@ import { getReposByGithub } from './actions/projects';
 import { getUser } from './actions/user';
 
 import { login, logout } from './auth/authActions';
-import { getRate, getRewardFund, getTrendingTopics } from './app/appActions';
+import { getRate, getRewardFund, getTrendingTopics, getCurrentMedianHistoryPrice } from './app/appActions';
 import Topnav from './components/Navigation/Topnav';
 import Transfer from './wallet/Transfer';
 import * as reblogActions from './app/Reblog/reblogActions';
@@ -30,6 +30,7 @@ import getTranslations, { getAvailableLocale } from './translations';
     getRate,
     getRewardFund,
     getTrendingTopics,
+    getCurrentMedianHistoryPrice,
     getRebloggedList: reblogActions.getRebloggedList,
     getReposByGithub,
     getUser,
@@ -47,6 +48,7 @@ export default class Wrapper extends React.PureComponent {
     getRate: PropTypes.func,
     getRewardFund: PropTypes.func,
     getTrendingTopics: PropTypes.func,
+    getCurrentMedianHistoryPrice: PropTypes.func,
   };
 
   static defaultProps = {
@@ -56,6 +58,7 @@ export default class Wrapper extends React.PureComponent {
     getRate: () => {},
     getRewardFund: () => {},
     getTrendingTopics: () => {},
+    getCurrentMedianHistoryPrice: () => {},
   };
 
   state = {
@@ -71,6 +74,7 @@ export default class Wrapper extends React.PureComponent {
     this.props.getRebloggedList();
     this.props.getRate();
     this.props.getTrendingTopics();
+    this.props.getCurrentMedianHistoryPrice();
   }
 
   componentDidUpdate () {

--- a/src/app/appActions.js
+++ b/src/app/appActions.js
@@ -19,6 +19,11 @@ export const GET_TRENDING_TOPICS_START = '@app/GET_TRENDING_TOPICS_START';
 export const GET_TRENDING_TOPICS_SUCCESS = '@app/GET_TRENDING_TOPICS_SUCCESS';
 export const GET_TRENDING_TOPICS_ERROR = '@app/GET_TRENDING_TOPICS_ERROR';
 
+export const GET_CURRENT_MEDIAN_HISTORY_PRICE = '@app/GET_CURRENT_MEDIAN_HISTORY_PRICE';
+export const GET_CURRENT_MEDIAN_HISTORY_PRICE_START = '@app/GET_CURRENT_MEDIAN_HISTORY_PRICE_START';
+export const GET_CURRENT_MEDIAN_HISTORY_PRICE_SUCCESS = '@app/GET_CURRENT_MEDIAN_HISTORY_PRICE_SUCCESS';
+export const GET_CURRENT_MEDIAN_HISTORY_PRICE_ERROR = '@app/GET_CURRENT_MEDIAN_HISTORY_PRICE_ERROR';
+
 export const RATE_REQUEST = '@app/RATE_REQUEST';
 export const RATE_SUCCESS = '@app/RATE_SUCCESS';
 
@@ -51,6 +56,14 @@ export const getRewardFund = () => (dispatch, getSelection, { steemAPI }) => {
   return dispatch({
     type: GET_REWARD_FUND,
     payload: { promise: getRewardFundAsync('post') },
+  });
+};
+
+export const getCurrentMedianHistoryPrice = () => (dispatch, getState, { steemAPI }) => {
+  const getCurrentMedianHistoryPriceAsync = Promise.promisify(steemAPI.getCurrentMedianHistoryPrice, { context: steemAPI });
+  return dispatch({
+    type: GET_CURRENT_MEDIAN_HISTORY_PRICE,
+    payload: { promise: getCurrentMedianHistoryPriceAsync() },
   });
 };
 

--- a/src/app/appReducer.js
+++ b/src/app/appReducer.js
@@ -11,6 +11,7 @@ const initialState = {
   rewardFund: {},
   trendingTopicsLoading: false,
   trendingTopics: [],
+  currentMedianHistoryPrice: {},
 };
 
 export default (state = initialState, action) => {
@@ -83,6 +84,15 @@ export default (state = initialState, action) => {
         trendingTopicsLoading: false,
         trendingTopics: [],
       };
+    case appTypes.GET_CURRENT_MEDIAN_HISTORY_PRICE_SUCCESS:
+      console.log(state);
+      return {
+        ...state,
+        currentMedianHistoryPrice: {
+          ...state.currentMedianHistoryPrice,
+          ...action.payload,
+        },
+      };
     default:
       return state;
   }
@@ -95,3 +105,4 @@ export const getRewardFund = state => state.rewardFund;
 export const getIsTrendingTopicsLoading = state => state.trendingTopicsLoading;
 export const getTrendingTopics = state => state.trendingTopics;
 export const getIsFetching = state => state.isFetching;
+export const getCurrentMedianHistoryPrice = state => state.currentMedianHistoryPrice;

--- a/src/comments/Comments.js
+++ b/src/comments/Comments.js
@@ -13,6 +13,7 @@ import {
   getAuthenticatedUserName,
   getVotingPower,
   getRewardFund,
+  getCurrentMedianHistoryPrice,
   getVotePercent,
 } from '../reducers';
 import CommentsList from '../components/Comments/Comments';
@@ -30,6 +31,7 @@ import './Comments.less';
     username: getAuthenticatedUserName(state),
     sliderMode: getVotingPower(state),
     rewardFund: getRewardFund(state),
+    currentMedianHistoryPrice: getCurrentMedianHistoryPrice(state),
     defaultVotePercent: getVotePercent(state),
   }),
   dispatch =>
@@ -49,6 +51,7 @@ export default class Comments extends React.Component {
     authenticated: PropTypes.bool.isRequired,
     user: PropTypes.shape().isRequired,
     rewardFund: PropTypes.shape().isRequired,
+    currentMedianHistoryPrice: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
     username: PropTypes.string,
@@ -147,6 +150,7 @@ export default class Comments extends React.Component {
       show,
       sliderMode,
       rewardFund,
+      currentMedianHistoryPrice,
       defaultVotePercent,
     } = this.props;
     const postId = post.id;
@@ -178,6 +182,7 @@ export default class Comments extends React.Component {
           show={show}
           notify={this.props.notify}
           rewardFund={rewardFund}
+          currentMedianHistoryPrice={currentMedianHistoryPrice}
           sliderMode={sliderMode}
           defaultVotePercent={defaultVotePercent}
           onLikeClick={this.handleLikeClick}

--- a/src/components/CommentFooter/CommentFooter.js
+++ b/src/components/CommentFooter/CommentFooter.js
@@ -11,6 +11,7 @@ export default class CommentFooter extends React.Component {
     user: PropTypes.shape().isRequired,
     comment: PropTypes.shape().isRequired,
     rewardFund: PropTypes.shape().isRequired,
+    currentMedianHistoryPrice: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
     editable: PropTypes.bool,
@@ -88,11 +89,12 @@ export default class CommentFooter extends React.Component {
   handleSliderCancel = () => this.setState({ sliderVisible: false });
 
   handleSliderChange = (value) => {
-    const { user, rewardFund } = this.props;
+    const { user, rewardFund, currentMedianHistoryPrice } = this.props;
     const voteWorth = getVoteValue(
       user,
       rewardFund.recent_claims,
       rewardFund.reward_balance,
+      currentMedianHistoryPrice,
       value * 100,
     );
     this.setState({ sliderValue: value, voteWorth });

--- a/src/components/Comments/Comment.js
+++ b/src/components/Comments/Comment.js
@@ -33,6 +33,7 @@ import './Comment.less';
     parent: PropTypes.shape().isRequired,
     sort: PropTypes.oneOf(['BEST', 'NEWEST', 'OLDEST']),
     rewardFund: PropTypes.shape().isRequired,
+    currentMedianHistoryPrice: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
     rootPostAuthor: PropTypes.string,
@@ -197,6 +198,7 @@ import './Comment.less';
       depth,
       sliderMode,
       rewardFund,
+      currentMedianHistoryPrice,
       defaultVotePercent,
     } = this.props;
     const { showHiddenComment } = this.state;
@@ -298,6 +300,7 @@ import './Comment.less';
             comment={comment}
             pendingVotes={pendingVotes}
             rewardFund={rewardFund}
+            currentMedianHistoryPrice={currentMedianHistoryPrice}
             sliderMode={sliderMode}
             defaultVotePercent={defaultVotePercent}
             onLikeClick={this.props.onLikeClick}
@@ -339,6 +342,7 @@ import './Comment.less';
                   commentsChildren={commentsChildren}
                   notify={this.props.notify}
                   rewardFund={rewardFund}
+                  currentMedianHistoryPrice={currentMedianHistoryPrice}
                   sliderMode={sliderMode}
                   defaultVotePercent={defaultVotePercent}
                   onLikeClick={this.props.onLikeClick}

--- a/src/components/Comments/Comments.js
+++ b/src/components/Comments/Comments.js
@@ -39,6 +39,7 @@ class Comments extends React.Component {
       }),
     ),
     rewardFund: PropTypes.shape().isRequired,
+    currentMedianHistoryPrice: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
     loading: PropTypes.bool,
@@ -148,6 +149,7 @@ class Comments extends React.Component {
       username,
       sliderMode,
       rewardFund,
+      currentMedianHistoryPrice,
       defaultVotePercent,
     } = this.props;
     const { sort } = this.state;
@@ -205,6 +207,7 @@ class Comments extends React.Component {
               pendingVotes={pendingVotes}
               notify={this.props.notify}
               rewardFund={rewardFund}
+              currentMedianHistoryPrice={currentMedianHistoryPrice}
               sliderMode={sliderMode}
               defaultVotePercent={defaultVotePercent}
               onLikeClick={onLikeClick}

--- a/src/components/Story/StoryFull.js
+++ b/src/components/Story/StoryFull.js
@@ -62,6 +62,7 @@ class StoryFull extends React.Component {
     post: PropTypes.shape().isRequired,
     postState: PropTypes.shape().isRequired,
     rewardFund: PropTypes.shape().isRequired,
+    currentMedianHistoryPrice: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
     pendingLike: PropTypes.bool,
     pendingFollow: PropTypes.bool,
@@ -222,6 +223,7 @@ class StoryFull extends React.Component {
       commentCount,
       saving,
       rewardFund,
+      currentMedianHistoryPrice,
       ownPost,
       sliderMode,
       defaultVotePercent,
@@ -843,6 +845,7 @@ class StoryFull extends React.Component {
           user={user}
           ownPost={ownPost}
           rewardFund={rewardFund}
+          currentMedianHistoryPrice={currentMedianHistoryPrice}
           sliderMode={sliderMode}
           defaultVotePercent={defaultVotePercent}
           post={post}

--- a/src/components/StoryFooter/StoryFooter.js
+++ b/src/components/StoryFooter/StoryFooter.js
@@ -31,6 +31,7 @@ class StoryFooter extends React.Component {
     post: PropTypes.shape().isRequired,
     postState: PropTypes.shape().isRequired,
     rewardFund: PropTypes.shape().isRequired,
+    currentMedianHistoryPrice: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
     ownPost: PropTypes.bool,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
@@ -68,7 +69,7 @@ class StoryFooter extends React.Component {
   }
 
   loadSponsorship() {
-    const { user, post, getProject, defaultVotePercent, rewardFund } = this.props;
+    const { user, post, getProject, defaultVotePercent, rewardFund, currentMedianHistoryPrice } = this.props;
     const postData = post.json_metadata;
     const repository = postData.repository;
     const repoId = repository.id;
@@ -93,6 +94,7 @@ class StoryFooter extends React.Component {
                       sponsorsAccount,
                       rewardFund.recent_claims,
                       rewardFund.reward_balance,
+                      currentMedianHistoryPrice,
                       sponsorsVote.percent / 100 * 100,
                     )
                   });
@@ -105,6 +107,7 @@ class StoryFooter extends React.Component {
                       sponsorsAccount,
                       rewardFund.recent_claims,
                       rewardFund.reward_balance,
+                      currentMedianHistoryPrice,
                       defaultVotePercent / 100 * 100,
                     )
                   });
@@ -180,7 +183,7 @@ class StoryFooter extends React.Component {
   handleSliderCancel = () => this.setState({ sliderVisible: false });
 
   handleSliderChange = (value) => {
-    const { user, rewardFund } = this.props;
+    const { post, user, rewardFund, currentMedianHistoryPrice } = this.props;
     const { sponsorsAccount } = this.state;
 
     if (!this.state.voteWithSponsors) {
@@ -188,6 +191,7 @@ class StoryFooter extends React.Component {
         user,
         rewardFund.recent_claims,
         rewardFund.reward_balance,
+        currentMedianHistoryPrice,
         value * 100,
       );
       this.setState({ sliderValue: value, voteWorth });
@@ -196,6 +200,7 @@ class StoryFooter extends React.Component {
         sponsorsAccount,
         rewardFund.recent_claims,
         rewardFund.reward_balance,
+        currentMedianHistoryPrice,
         value * 100,
       );
       this.setState({ sliderSponsorsValue: value, sponsorsVoteWorth });

--- a/src/components/StoryFooter/StoryFooter.js
+++ b/src/components/StoryFooter/StoryFooter.js
@@ -183,7 +183,7 @@ class StoryFooter extends React.Component {
   handleSliderCancel = () => this.setState({ sliderVisible: false });
 
   handleSliderChange = (value) => {
-    const { post, user, rewardFund, currentMedianHistoryPrice } = this.props;
+    const { user, rewardFund, currentMedianHistoryPrice } = this.props;
     const { sponsorsAccount } = this.state;
 
     if (!this.state.voteWithSponsors) {

--- a/src/helpers/user.js
+++ b/src/helpers/user.js
@@ -35,11 +35,12 @@ parseFloat(user.received_vesting_shares) +
 
 export const getHasDefaultSlider = user => true;
 
-export const getVoteValue = (user, recentClaims, rewardBalance, weight = 10000) =>
+export const getVoteValue = (user, recentClaims, rewardBalance, currentMedianHistoryPrice, weight = 10000) =>
   calculateVoteValue(
     getTotalShares(user),
     parseFloat(recentClaims),
     parseFloat(rewardBalance),
+    currentMedianHistoryPrice,
     user.voting_power,
     weight,
   );

--- a/src/post/PostContent.js
+++ b/src/post/PostContent.js
@@ -18,6 +18,7 @@ import {
   getIsEditorSaving,
   getVotingPower,
   getRewardFund,
+  getCurrentMedianHistoryPrice,
   getVotePercent,
 } from '../reducers';
 import { editPost } from './Write/editorActions';
@@ -45,6 +46,7 @@ import { moderatorAction } from '../actions/contribution';
     moderators: state.moderators,
     sliderMode: getVotingPower(state),
     rewardFund: getRewardFund(state),
+    currentMedianHistoryPrice: getCurrentMedianHistoryPrice(state),
     defaultVotePercent: getVotePercent(state),
   }),
   {
@@ -70,6 +72,7 @@ class PostContent extends React.Component {
     pendingBookmarks: PropTypes.arrayOf(PropTypes.number).isRequired,
     saving: PropTypes.bool.isRequired,
     rewardFund: PropTypes.shape().isRequired,
+    currentMedianHistoryPrice: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
     bookmarks: PropTypes.shape(),
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
@@ -153,6 +156,7 @@ class PostContent extends React.Component {
       saving,
       sliderMode,
       rewardFund,
+      currentMedianHistoryPrice,
       defaultVotePercent,
       moderatorAction,
       moderators,
@@ -227,6 +231,7 @@ class PostContent extends React.Component {
           pendingBookmark={pendingBookmarks.includes(content.id)}
           saving={saving}
           rewardFund={rewardFund}
+          currentMedianHistoryPrice={currentMedianHistoryPrice}
           sliderMode={sliderMode}
           defaultVotePercent={defaultVotePercent}
           ownPost={author === user.name}

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -81,6 +81,7 @@ export const getRate = state => fromApp.getRate(state.app);
 export const getIsTrendingTopicsLoading = state => fromApp.getIsTrendingTopicsLoading(state.app);
 export const getTrendingTopics = state => fromApp.getTrendingTopics(state.app);
 export const getRewardFund = state => fromApp.getRewardFund(state.app);
+export const getCurrentMedianHistoryPrice = state => fromApp.getCurrentMedianHistoryPrice(state.app);
 export const getIsFetching = state => fromApp.getIsFetching(state.app);
 
 

--- a/src/vendor/steemitHelpers.js
+++ b/src/vendor/steemitHelpers.js
@@ -167,11 +167,12 @@ export function getBodyPatchIfSmaller(originalBody, body) {
 /**
  * https://github.com/aaroncox/chainbb/blob/fcb09bee716e907c789a6494975093361482fb4f/services/frontend/src/components/elements/post/button/vote/options.js#L69
  */
-export const calculateVoteValue = (vests, recentClaims, rewardBalance, vp = 10000, weight = 10000) => {
+export const calculateVoteValue = (vests, recentClaims, rewardBalance, currentMedianHistoryPrice, vp = 10000, weight = 10000) => {
   const vestingShares = parseInt(vests * 1e6, 10);
   const power = (((vp * weight) / 10000) / 50);
   const rshares = (power * vestingShares) / 10000;
-  return rshares / recentClaims * rewardBalance;
+  const sbd_median_price = parseFloat(currentMedianHistoryPrice.base) / parseFloat(currentMedianHistoryPrice.quote);
+  return rshares / recentClaims * rewardBalance * sbd_median_price;
 };
 
 export const calculateTotalDelegatedSP = (user, totalVestingShares, totalVestingFundSteem) => {


### PR DESCRIPTION
Voting slider in utopian.io was inaccurate. SBD price spike broke the mechanism completely. The formula had to be updated by current_median_history_price factor.

Old:
![image](https://user-images.githubusercontent.com/17079510/34642345-9c40c312-f311-11e7-9892-aaee5bc6f9a1.png)

Fixed:
![image](https://user-images.githubusercontent.com/17079510/34642349-a603dede-f311-11e7-9c9e-ed8856630991.png)

True values:
![image](https://user-images.githubusercontent.com/17079510/34642353-bf0e0954-f311-11e7-8dcb-b37dc69f5ad1.png)
