### PR TITLE
Fix user rank on the profile page

### DIFF
--- a/src/helpers/user.js
+++ b/src/helpers/user.js
@@ -2,6 +2,7 @@ import { calculateVoteValue } from '../vendor/steemitHelpers';
 
 export const getUserRank = (vests) => {
   let rank = 'Plankton';
+  vests = parseFloat(vests);
   if (vests >= 1000000000) {
     rank = 'Whale';
   } else if (vests >= 100000000) {
@@ -16,6 +17,7 @@ export const getUserRank = (vests) => {
 
 export const getUserRankKey = (vests) => {
   let rank = 'plankton';
+  vests = parseFloat(vests);
   if (vests >= 1000000000) {
     rank = 'whale';
   } else if (vests >= 100000000) {


### PR DESCRIPTION
Issue: every user's visible rank is "Plankton". It didn't change depending on Vests amount. The problem was incorrect number parsing from string text ("XXX VESTS")

![image](https://user-images.githubusercontent.com/17079510/35062939-e844dfca-fbc5-11e7-9ed3-32b144077b65.png)

![image](https://user-images.githubusercontent.com/17079510/35062944-eca0552c-fbc5-11e7-9fe2-c26df168e035.png)
