### PR TITLE
updated development rules

### DIFF
--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -62,7 +62,7 @@ export const Rules = ({type, acceptRules, inEditor}) => {
             <li>Trivial code snippets, example code or simple templates will not be accepted.</li>
             <li><b>Bug Fixes</b> and <b>New Features</b> must be submitted via Pull Requests. The Pull Request must have been <b>merged within the past 14 days</b>.</li>
             <li>Updates on <b>Own Projects</b> can be committed directly, without a Pull Request. <b>Commits must not be older than 14 days.</b></li>
-            <li><b>Bug Fixes</b> for your <b>Own Projects</b> will not be accepted.</li>
+            <li><b>Bug Fixes</b> for your <b>Own Projects</b> will not be accepted, unless they are caused by third party dependencies.</li>
             <li>Your Utopian account must be connected to your GitHub account.</li>
           </ul>
           <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -54,13 +54,16 @@ export const Rules = ({type, acceptRules, inEditor}) => {
           <h2><CategoryIcon from="from-rules"  type="development"/> Development Rules</h2>
           {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
-            <li>Only merged Pull Requests will be accepted.</li>
-            <li>Only merged Pull Requests on the official repository will be accepted or on a fork as long as the fork is not just a mirror of the original one.</li>
-            <li>The contribution will be rejected if the merged Pull Request is <b>older than 7 days</b> since the submitted contribution.</li>
-            <li>Simple and common code snippets that can be easily found or reproduced can't be submitted in the development category.</li>
-            <li>You must always link the merged pull requests with the given functionality in the editor.</li>
-            <li>If your username on Github does not correspond to the Utopian username you must use the "Name" field in the Github settings and enter there your Utopian/Steem username to verify you are the author.</li>
-            <li>Images, screenshots, links and examples are not necessary but preferred.</li>
+            <li>In the development category you can submit <b>Bug Fixes</b>, <b>New Features</b> and your <b>Own Projects</b>.</li>
+            <li>Contributions must have a comprehensible commit history. Larger projects or updates submitted in a single commit will not be accepted.</li>
+            <li>Outdated or low quality code can lead to rejection.</li>
+            <li>Generated code or other results of automated processes will not be accepted.</li>
+            <li>Submitted projects must have a unique value. Redundant projects will not be accepted.</li>
+            <li>Trivial code snippets, example code or simple templates will not be accepted.</li>
+            <li><b>Bug Fixes</b> and <b>New Features</b> must be submitted via Pull Requests. The Pull Request must have been <b>merged within the past 14 days</b>.</li>
+            <li>Updates on <b>Own Projects</b> can be committed directly, without a Pull Request. <b>Commits must not be older than 14 days.</b></li>
+            <li><b>Bug Fixes</b> for your <b>Own Projects</b> will not be accepted.</li>
+            <li>Your Utopian account must be connected to your GitHub account.</li>
           </ul>
           <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
           {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}


### PR DESCRIPTION
*Some explanation for the changes:*

#### In the development category you can submit Bug Fixes, New Features and your Own Projects.
This addresses the fact that there are different types of contributions that need to be handled differently, which is reflected in the other rules.

#### Contributions must have a comprehensible commit history. Larger projects or updates submitted in a single commit will not be accepted.
Contributors get rewarded for their work and therefore this work has to be evaluated by the moderators first. This is simply not possible if contributors don't use Git in it's intended way and make commits, that crash the browser when viewed on GitHub.

#### Outdated or low quality code can lead to rejection.
Software should always be activley maintained and up to date because hopefully there are users who are actually using it and relying on it.

#### Generated code or other results of automated processes will not be accepted.
No work. No reward. Makes sense I guess. We had contributions that only contained an updated dependencies file or unified code formatting.

#### Submitted projects must have a unique value. Redundant projects will not be accepted.
Utopian can reward one super awesome innovative calculator app and maybe two or three. But if we accept more than one there will be hundreds. Aside from this, there's no real added value.

#### Trivial code snippets, example code or simple templates will not be accepted.
Everyone has to start somewhere, sure... but Utopian can't reward every beginner programmer out there and projects on Utopian should have a real world usage and a realistic future.

#### Bug Fixes and New Features must be submitted via Pull Requests. The Pull Request must have been merged within the past 14 days.
This is just like before but you know have 14 days.

#### Updates on Own Projects can be committed directly, without a Pull Request. Commits must not be older than 14 days.
Of course PRs don't necessarily make much sense if you work on your own project. This is now reflected in the rules.

#### Bug Fixes for your Own Projects will not be accepted, unless they are caused by third party dependencies..
This is just to avoid specially "prepared" project submissions. It also doesn't make much sense to be rewarded for fixing your own bugs in general.

#### Your Utopian account must be connected to your GitHub account.
Makes proof of account ownership much easier for moderators and contributors. No need for screenshots or mentioning your utopian username on GitHub and what not... For the development category I think this requirement totally makes sense.
