### PR TITLE
updated bug-hunting rules

### DIFF
--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -72,12 +72,17 @@ export const Rules = ({type, acceptRules, inEditor}) => {
           <h2><CategoryIcon from="from-rules"  type="bug-hunting"/> Bug Hunting Rules</h2>
           {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
-            <li>In this category you can only report bugs you have found in an Open Source project.</li>
-            <li>You must provide every possible detail to reproduce the bug.</li>
-            <li>You should show a video or an animated GIF if the bug can be recorded on screen.</li>
-            <li>You must include: browsers, devices, operating systems used and similar info to reproduce the bug.</li>
+            <li>In this category you can submit <b>Bug Reports</b> for actively maintained Open Source projects on GitHub.</li>
+            <li>The repository on GitHub must accept <a href="https://help.github.com/articles/about-issues/">issues</a>.</li>
+            <li><b>Bug Reports</b> for projects in <a href="https://en.wikipedia.org/wiki/Software_release_life_cycle">pre-alpha stage</a> will not be accepted.</li>
+            <li>Cosmetic issues, that do not affect the functionality of the software, will not be accepted.</li>
+            <li>You must provide sufficiant detail to reproduce the bug.</li>
+            <li>Add screenshots, video recordings or animated GIFs, if they can help to understand the bug. [SOFT]</li>
+            <li>Include information about your technical environment, like your browser, your device and operating system, if those factors can not definitely be ruled out.</li>
+            <li>If you or someone else submitted the issue on GitHub first, the <b>Bug Report</b> will not be accepted. Approved <b>Bug Reports</b> will automatically be published on GitHub.</li>
+            <li>Your Utopian account must be connected to your GitHub account.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
+          <p>Not respecting the rules will either give you lower votes or your contribution will not be accepted.</p>
           {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )


### PR DESCRIPTION
*Some explanation for the changes:*

**Your Utopian account must be connected to your GitHub account.
The repository on GitHub must accept <a href="https://help.github.com/articles/about-issues/">issues</a>.**

This makes sure an issue on GitHub is filed and the project maintainer has a chance to actually see the bug and react.

**<b>Bug Reports</b> for projects in <a href="https://en.wikipedia.org/wiki/Software_release_life_cycle">pre-alpha stage</a> will not be accepted.**

To avoid being flooded with bugs, we need to draw a clear line. Projects that are in very early stage (preview/pre-alpha) obviously contain a lot of bugs and the developers probably know about them or at least the about fact that there are bugs. I think this Wikipedia article gives us a clear definition.

**Cosmetic issues, that do not affect the functionality of the software, will not be accepted.**

For cosmetic issues it's simply not really possible to draw this clear line and we can't accept every small pixel issue. In the future we can integrate different levels of severity in the rewards but for now it does not make sense to accept those "bugs".

**You must provide sufficiant detail to reproduce the bug.
Add screenshots, video recordings or animated GIFs, if they can help to understand the bug. [SOFT]**

Obvious...

**Include information about your technical environment, like your browser, your device and operating system, if those factors can not definitely be ruled out.**

This information is of course important for most bugs but it's just the same as with screenshots and so on... sometimes they just don't add any relevant information. E.g. if a server returns an error if the limit parameter is > 100... it's very unlikely that this has anything to do with browser, device or OS.

**If you or someone else submitted the issue on GitHub first, the <b>Bug Report</b> will not be accepted. Approved <b>Bug Reports</b> will automatically be published on GitHub.**

This is just a more precise and Bug Hunting specific version of the general rule "Same contents already shared before in Utopian..."
