### PR TITLE
Feature/Add Code Block Highlighting + Code Block Bug Fix + Code Block Toolbar Button

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "extract-text-webpack-plugin": "^2.1.2",
     "file-loader": "^0.11.2",
     "gulp": "^3.9.1",
+    "highlight.js": "^9.12.0",
     "history": "^4.6.3",
     "html-loader": "^0.4.5",
     "html-webpack-plugin": "^2.28.0",

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -87,6 +87,7 @@ class Editor extends React.Component {
     quote: 'ctrl+q',
     link: 'ctrl+k',
     image: 'ctrl+m',
+    code: 'ctrl+n',
   };
 
   state = {
@@ -148,7 +149,7 @@ class Editor extends React.Component {
   }
 
 
-  
+
 
   componentWillUnmount() {
     if (document.getElementsByClassName("cometchat_ccmobiletab_redirect") && document.getElementsByClassName("cometchat_ccmobiletab_redirect")[0]) {
@@ -511,6 +512,9 @@ class Editor extends React.Component {
       case 'image':
         this.insertAtCursor('![', '](url)', 2, 2);
         break;
+      case 'code':
+        this.insertAtCursor('``` language\n', '\n```', 4, 12);
+        break;
       default:
         break;
     }
@@ -535,11 +539,12 @@ class Editor extends React.Component {
       this.insertCode('link');
     },
     image: () => this.insertCode('image'),
+    code: () => this.insertCode('code'),
   };
 
   renderMarkdown = (value) => {
     this.setState({
-      contentHtml: remarkable.render(value),
+      contentHtml: value,
     });
   };
 

--- a/src/components/Editor/EditorTask.js
+++ b/src/components/Editor/EditorTask.js
@@ -76,6 +76,7 @@ class EditorTask extends React.Component {
     quote: 'ctrl+q',
     link: 'ctrl+k',
     image: 'ctrl+m',
+    code: 'ctrl+n',
   };
 
   state = {
@@ -431,6 +432,9 @@ class EditorTask extends React.Component {
       case 'image':
         this.insertAtCursor('![', '](url)', 2, 2);
         break;
+      case 'code':
+        this.insertAtCursor('``` language\n', '\n```', 4, 12);
+        break;
       default:
         break;
     }
@@ -455,11 +459,12 @@ class EditorTask extends React.Component {
       this.insertCode('link');
     },
     image: () => this.insertCode('image'),
+    code: () => this.insertCode('code'),
   };
 
   renderMarkdown = (value) => {
     this.setState({
-      contentHtml: remarkable.render(value),
+      contentHtml: value,
     });
   };
 

--- a/src/components/Editor/EditorToolbar.js
+++ b/src/components/Editor/EditorToolbar.js
@@ -57,6 +57,11 @@ const EditorToolbar = ({ intl, onSelect }) => {
           <i className="iconfont icon-picture" />
         </Button>
       </Tooltip>
+      <Tooltip title={tooltip(intl.formatMessage({ id: 'code', defaultMessage: 'Insert Code' }), 'Ctrl+n')}>
+        <Button className="EditorToolbar__button" onClick={() => onSelect('code')}>
+          <i className="iconfont icon-code" />
+        </Button>
+      </Tooltip>
     </div>
   );
 };

--- a/src/components/Story/Body.js
+++ b/src/components/Story/Body.js
@@ -10,14 +10,27 @@ import sanitizeConfig from '../../vendor/SanitizeConfig';
 import { imageRegex } from '../../helpers/regexHelpers';
 import htmlReady from '../../vendor/steemitHtmlReady';
 import PostFeedEmbed from './PostFeedEmbed';
+import hljs from 'highlight.js';
+
 import './Body.less';
 
 export const remarkable = new Remarkable({
   html: true, // remarkable renders first then sanitize runs...
-  breaks: true,
+  breaks: false,
   linkify: false, // linkify is done locally
   typographer: false, // https://github.com/jonschlinkert/remarkable/issues/142#issuecomment-221546793
   quotes: '“”‘’',
+  highlight: (str, lang) => {
+    if (lang && hljs.getLanguage(lang)) {
+      try {
+        return hljs.highlight(lang, str).value;
+      } catch (err) { return ''; }
+    }
+
+    try {
+      return hljs.highlightAuto(str).value;
+    } catch (err) { return ''; }
+  },
 });
 
 // Should return text(html) if returnType is text
@@ -33,11 +46,14 @@ export function getHtml(body, jsonMetadata = {}, returnType = 'Object') {
       parsedJsonMetadata.image.push(img);
     }
   });
-
+  console.log(parsedBody);
   const htmlReadyOptions = { mutate: true, resolveIframe: returnType === 'text' };
   parsedBody = remarkable.render(parsedBody);
+  console.log(parsedBody);
   parsedBody = htmlReady(parsedBody, htmlReadyOptions).html;
+  console.log(parsedBody);
   parsedBody = sanitizeHtml(parsedBody, sanitizeConfig({}));
+  console.log(parsedBody);
   if (returnType === 'text') {
     return parsedBody;
   }

--- a/src/components/Story/Body.js
+++ b/src/components/Story/Body.js
@@ -5,12 +5,12 @@ import classNames from 'classnames';
 import sanitizeHtml from 'sanitize-html';
 import Remarkable from 'remarkable';
 import embedjs from 'embedjs';
+import hljs from 'highlight.js';
 import { jsonParse } from '../../helpers/formatter';
 import sanitizeConfig from '../../vendor/SanitizeConfig';
 import { imageRegex } from '../../helpers/regexHelpers';
 import htmlReady from '../../vendor/steemitHtmlReady';
 import PostFeedEmbed from './PostFeedEmbed';
-import hljs from 'highlight.js';
 
 import './Body.less';
 
@@ -46,14 +46,10 @@ export function getHtml(body, jsonMetadata = {}, returnType = 'Object') {
       parsedJsonMetadata.image.push(img);
     }
   });
-  console.log(parsedBody);
   const htmlReadyOptions = { mutate: true, resolveIframe: returnType === 'text' };
   parsedBody = remarkable.render(parsedBody);
-  console.log(parsedBody);
   parsedBody = htmlReady(parsedBody, htmlReadyOptions).html;
-  console.log(parsedBody);
   parsedBody = sanitizeHtml(parsedBody, sanitizeConfig({}));
-  console.log(parsedBody);
   if (returnType === 'text') {
     return parsedBody;
   }

--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -199,4 +199,99 @@
       margin: 0 0 1.5rem 0;
     }
   }
+
+  // Code Highlighting styling --> See highlight.js for more
+  .hljs {
+    display: block;
+    overflow-x: auto;
+    padding: 0.5em;
+    color: #333;
+    background: #f8f8f8;
+  }
+
+  .hljs-comment,
+  .hljs-quote {
+    color: #998;
+    font-style: italic;
+  }
+
+  .hljs-keyword,
+  .hljs-selector-tag,
+  .hljs-subst {
+    color: #333;
+    font-weight: bold;
+  }
+
+  .hljs-number,
+  .hljs-literal,
+  .hljs-variable,
+  .hljs-template-variable,
+  .hljs-tag .hljs-attr {
+    color: #008080;
+  }
+
+  .hljs-string,
+  .hljs-doctag {
+    color: #d14;
+  }
+
+  .hljs-title,
+  .hljs-section,
+  .hljs-selector-id {
+    color: #900;
+    font-weight: bold;
+  }
+
+  .hljs-subst {
+    font-weight: normal;
+  }
+
+  .hljs-type,
+  .hljs-class .hljs-title {
+    color: #458;
+    font-weight: bold;
+  }
+
+  .hljs-tag,
+  .hljs-name,
+  .hljs-attribute {
+    color: #000080;
+    font-weight: normal;
+  }
+
+  .hljs-regexp,
+  .hljs-link {
+    color: #009926;
+  }
+
+  .hljs-symbol,
+  .hljs-bullet {
+    color: #990073;
+  }
+
+  .hljs-built_in,
+  .hljs-builtin-name {
+    color: #0086b3;
+  }
+
+  .hljs-meta {
+    color: #999;
+    font-weight: bold;
+  }
+
+  .hljs-deletion {
+    background: #fdd;
+  }
+
+  .hljs-addition {
+    background: #dfd;
+  }
+
+  .hljs-emphasis {
+    font-style: italic;
+  }
+
+  .hljs-strong {
+    font-weight: bold;
+  }
 }

--- a/src/vendor/SanitizeConfig.js
+++ b/src/vendor/SanitizeConfig.js
@@ -46,7 +46,7 @@ export const allowedTags = `
     div, iframe, del,
     a, p, b, q, br, ul, li, ol, img, h1, h2, h3, h4, h5, h6, hr,
     blockquote, pre, code, em, strong, center, table, thead, tbody, tr, th, td,
-    strike, sup, sub
+    span, strike, sup, sub
 `
   .trim()
   .split(/,\s*/);
@@ -70,7 +70,9 @@ export default ({ large = true, noImage = false, sanitizeErrors = [] }) => ({
     ],
 
     // class attribute is strictly whitelisted (below)
+    code: ['class'],
     div: ['class'],
+    span: ['class'],
 
     // style is subject to attack, filtering more below
     td: ['style'],


### PR DESCRIPTION
I am using Utopian.io for quite a time now and realised using code blocks is buggy. Also code blocks do not use code highlighting and a toolbox button is missing. So I added it.

## Bug Fix
Currently when adding blank new lines inside a code block, the formatting after it is completely wrong and inside the code block

Example:
<img width="540" alt="screen shot 2018-01-30 at 17 20 56" src="https://user-images.githubusercontent.com/35397343/35577556-2926b682-05e2-11e8-9613-fa15564d410d.png">

I fixed it:
<img width="266" alt="screen shot 2018-01-30 at 17 21 15" src="https://user-images.githubusercontent.com/35397343/35577570-2e2203d0-05e2-11e8-8716-e5f98c390e78.png">

## Code Highlighting
When working with code examples it is always great to have a simple code highlighting, so the end-user can read the code more easily.

<img width="255" alt="screen shot 2018-01-30 at 17 24 22" src="https://user-images.githubusercontent.com/35397343/35577710-72554d00-05e2-11e8-83c8-b213de6cf390.png">

It works for the most basic programming languages and is supported by default from remarkable. To highlight the code correctly a new node package is used in combination with remarkable, named 'highlight.js' 

## Code Toolbar Button
<img width="164" alt="screen shot 2018-01-30 at 17 25 54" src="https://user-images.githubusercontent.com/35397343/35577810-a7d5141a-05e2-11e8-9be4-8138aeaaf10a.png">

Hotkey and Button both works, they insert a code block at the cursor position.


Overall some simple changes, to make have a better feeling by creating / reading posts on utopian.io

Thanks :)

PS: Since Discord Invitation is broken I directly created a PR.