### PR TITLE
Cookie policy hotfix & RWD

### DIFF
--- a/src/components/Navigation/Sidenav.js
+++ b/src/components/Navigation/Sidenav.js
@@ -85,7 +85,7 @@ const Sidenav = ({ username }) =>
         <li>
           <NavLink to="/cookies" activeClassName="Sidenav__item--active" isActive={(match, location) => isActive('/cookies', match, location)}>
             <Icon type="flag" style={{ 'verticalAlign': 'middle', 'fontSize': '22px', 'marginRight': '10px' }} />
-            FAQ
+            Cookie Policy
           </NavLink>
         </li>
       </ul>}

--- a/src/statics/CookiePolicyBanner.js
+++ b/src/statics/CookiePolicyBanner.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Icon } from 'antd';
+import { Button } from 'antd';
 import { withRouter, NavLink } from 'react-router-dom';
 import Cookies from 'js-cookie';
 import 'antd/dist/antd';
@@ -22,7 +22,7 @@ export default class CookiePolicyBanner extends Component {
 
     Cookies.set(
       'isCookiePolicyAccepted',
-      'true',
+      true,
       {
         expires: 3650, // ten years from now
         domain: process.env.NODE_ENV === 'development'
@@ -39,12 +39,20 @@ export default class CookiePolicyBanner extends Component {
 
     return (
       <div className="CookiePolicyBanner">
-        <p className="CookiePolicyBanner__PolicySummary">To help provide a safer and more optimal experience, we use cookies. By clicking or navigating the site, you agree to allow our collection of information on and off Utopian through cookies. Learn more, including about available controls: <NavLink to="/cookies">Cookies Policy.</NavLink></p>
+        <div>
+          <p className="CookiePolicyBanner__PolicySummary">
+            To help provide a safer and more optimal experience, we use cookies. By clicking or navigating the site, you agree to allow our collection of information on and off Utopian through cookies. Learn more, including about available controls: 
+            <NavLink className="CookiePolicyBanner__PolicyLink" to="/cookies">Cookies Policy</NavLink>.
+          </p>
+          <p className="CookiePolicyBanner__PolicySummary">
+            If you do not agree with our Cookie Policy, 
+            <a href="https://www.google.com" className="CookiePolicyBanner__PolicyLink">please leave the site</a>.
+          </p>
+        </div>
         <Button
           className="CookiePolicyBanner__ProceedButton"
           onClick={this.handleAcceptButtonClick}
-        ><Icon type="close" />
-        </Button>
+        >OK</Button>
       </div>
     );
   }

--- a/src/statics/CookiePolicyBanner.less
+++ b/src/statics/CookiePolicyBanner.less
@@ -12,14 +12,31 @@
   color: #ccc;
   
   &__PolicySummary {
-    max-width: 80em;
-    margin: 1em 0 1em 1em;
-
+    font-size: 90%;
+    max-width: 60em;
+    margin-left: 0.5em;
+    line-height: 105%;
     text-align: justify;
+    
+    &:first-child {
+      margin-top: 0.5em;
+    }
+
+    &:last-child {
+      margin-bottom: 0.5em;
+    }
+  }
+
+  &__PolicyLink {
+    color: #fff;
+    margin-left: 1em;
+    &:before {
+      content: ' ';
+    }
   }
 
   &__ProceedButton {
-    margin: 0 2em;
-    background-color: transparent;
+    margin: 0 3%;
+    height: 200%;
   }
 }


### PR DESCRIPTION
Hotfixes for commit #326:
- Better RWD support - now banner do not take too much space on mobile, screens:
![ipad](https://user-images.githubusercontent.com/18560168/36174662-3918c374-110d-11e8-8c9d-88109f60f14c.PNG)
![iphone](https://user-images.githubusercontent.com/18560168/36174665-3a2cd174-110d-11e8-9f8d-cd59c34ab1d3.PNG)
![desk](https://user-images.githubusercontent.com/18560168/36174668-3bce422e-110d-11e8-80ba-08fb8f419ba2.PNG)
- Hotfix: there was an issue in sidenav - I did a mistake, and didn't change aname for route in sidenav
- made links more readable: the links in my not calibrated screen looked good, but in reality the contrast was too low. Now links are white.