### PR TITLE
Feature/Inline Cross Editing

### DIFF
--- a/src/components/Story/StoryFull.js
+++ b/src/components/Story/StoryFull.js
@@ -747,6 +747,7 @@ class StoryFull extends React.Component {
           </span>
           )}
           </Tooltip>
+          
           <b>&nbsp;&nbsp;&middot;&nbsp;&nbsp;</b> <a href="#" onClick={() => {this.setState({shareModal: true})}}><ReactIcon.MdShare /> Share</a>
         </div>
         <Modal


### PR DESCRIPTION
Ref: #287

Completes:

Moderators should be able to edit inline:

a. Repository
b. Categories, even from contributions to task requests.
c. Tags.