### PR TITLE
use env var to switch between from utopian.app to utopian-test

### DIFF
--- a/src/sc2.js
+++ b/src/sc2.js
@@ -14,7 +14,8 @@ function getLoginUrl(state) {
 
   const response = 'response_type=code';
 
-  const clientId = 'client_id=utopian.app';
+  const app = process.env.UTOPIAN_APP || 'utopian.app';
+  const clientId = `client_id=${app}`;
   state = `state=${state ? encodeURIComponent(state) : ''}`;
   const scopes = [
     'vote',

--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -48,7 +48,7 @@ module.exports = {
         UTOPIAN_CATEGORY: JSON.stringify(process.env.UTOPIAN_CATEGORY || 'test-category'),
         UTOPIAN_LANDING_URL: JSON.stringify(process.env.UTOPIAN_LANDING_URL || 'http://join.utopian.io'),
         UTOPIAN_API: JSON.stringify(UTOPIAN_API),
-        UTOPIAN_APP: JSON.stringify('utopian.app'),
+        UTOPIAN_APP: JSON.stringify(process.env.UTOPIAN_APP || 'utopian.app'),
         UTOPIAN_GITHUB_CLIENT_ID: JSON.stringify(process.env.UTOPIAN_GITHUB_CLIENT_ID || '1ed58da028b638550c03'),
         UTOPIAN_GITHUB_REDIRECT_URL: JSON.stringify(UTOPIAN_GITHUB_REDIRECT_URL),
         STEEMJS_URL: JSON.stringify(process.env.STEEMJS_URL),


### PR DESCRIPTION
`UTOPIAN_APP` defaults to `'utopian.app'`

use `export UTOPIAN_APP=utopian-test` to switch to `'utopian-test'` or something else

(it's just annoying to change code for that....)