### PR TITLE
Feature/enable inline edit for contribs not yet accepted and supervisors

### DIFF
--- a/src/components/Story/Contribution.js
+++ b/src/components/Story/Contribution.js
@@ -155,12 +155,15 @@ const Contribution = ({
       {repository && platform && id ? <span>
         {' '} <b>&middot;</b> {'  '} <a href={`https://github.com/${repository.full_name}`}><Icon type='github' /></a>
         { isModerator && !post.reviewed ?
-          <InlineRepoEdit
+          <span>
+            {' '} <b>&middot;</b> {'  '} <Link to={`/project/${repository.full_name}/${platform}/${id}/all`}><Icon type="folder-open" /></Link>
+            <InlineRepoEdit
               value={parsedRepoName(repository.owner.login, repository.name)}
               post={post}
               moderatorAction={moderatorAction}
               user={user}
-          /> :
+            />
+          </span> ) :
           <Link to={`/project/${repository.full_name}/${platform}/${id}/all`}>{parsedRepoName(repository.owner.login, repository.name)}</Link>
         }
       </span> : null}

--- a/src/components/Story/Contribution.js
+++ b/src/components/Story/Contribution.js
@@ -139,7 +139,7 @@ const Contribution = ({
 
       <span className={`Contribution__c-${(fullMode === false) ? type : "yes-full"}`}>
         <CategoryIcon from="from-story" type={type}/>
-        { (isModerator && !post.reviewed) || (isModerator && isModerator.supermoderator === true) ?
+        { (isModerator && !post.json_metadata.moderator.reviewed) || (isModerator && isModerator.supermoderator === true) ?
           <InlineCategoryEdit
             value={type}
             types={types}
@@ -154,7 +154,7 @@ const Contribution = ({
 
       {repository && platform && id ? <span>
         {' '} <b>&middot;</b> {'  '} <a href={`https://github.com/${repository.full_name}`}><Icon type='github' /></a>
-        { (isModerator && !post.reviewed) || (isModerator && isModerator.supermoderator === true) ? (
+        { (isModerator && !post.json_metadata.moderator.reviewed) || (isModerator && isModerator.supermoderator === true) ? (
           <span>
             {' '} <b>&middot;</b> {'  '} <Link to={`/project/${repository.full_name}/${platform}/${id}/all`}><Icon type="folder-open" /></Link>
             <InlineRepoEdit

--- a/src/components/Story/Contribution.js
+++ b/src/components/Story/Contribution.js
@@ -139,7 +139,7 @@ const Contribution = ({
 
       <span className={`Contribution__c-${(fullMode === false) ? type : "yes-full"}`}>
         <CategoryIcon from="from-story" type={type}/>
-        { isModerator ?
+        { isModerator && !post.reviewed ?
           <InlineCategoryEdit
             value={type}
             types={types}
@@ -154,7 +154,7 @@ const Contribution = ({
 
       {repository && platform && id ? <span>
         {' '} <b>&middot;</b> {'  '} <a href={`https://github.com/${repository.full_name}`}><Icon type='github' /></a>
-        { isModerator ?
+        { isModerator && !post.reviewed ?
           <InlineRepoEdit
               value={parsedRepoName(repository.owner.login, repository.name)}
               post={post}

--- a/src/components/Story/Contribution.js
+++ b/src/components/Story/Contribution.js
@@ -154,7 +154,7 @@ const Contribution = ({
 
       {repository && platform && id ? <span>
         {' '} <b>&middot;</b> {'  '} <a href={`https://github.com/${repository.full_name}`}><Icon type='github' /></a>
-        { isModerator && !post.reviewed ?
+        { isModerator && !post.reviewed ? (
           <span>
             {' '} <b>&middot;</b> {'  '} <Link to={`/project/${repository.full_name}/${platform}/${id}/all`}><Icon type="folder-open" /></Link>
             <InlineRepoEdit

--- a/src/components/Story/InlineTagEdit.js
+++ b/src/components/Story/InlineTagEdit.js
@@ -109,7 +109,7 @@ class InlineTagEdit extends React.Component {
   handleRemoveTag(event) {
     event.preventDefault();
     const index = parseInt(event.target.attributes['data-index'].value, 10);
-    removeTag(index);
+    this.removeTag(index);
     setTimeout(() => {
       this.updatePostTags();
     }, 100);
@@ -132,7 +132,7 @@ class InlineTagEdit extends React.Component {
     if(event.target.value === '') {
       // remove added tag span when value is empty
       const index = parseInt(event.target.attributes['data-index'].value, 10);
-      removeTag(index);
+      this.removeTag(index);
     } else if (prevTags.sort().join(',') === newTags.sort().join(',')
         || !this.props.validation(newTags)) {
       // do nothing; do not broadcoast

--- a/src/components/Story/StoryFull.js
+++ b/src/components/Story/StoryFull.js
@@ -924,7 +924,7 @@ class StoryFull extends React.Component {
           />
         )}
         <div className="StoryFull__topics">
-          { isModerator ?
+          { isModerator && !post.reviewed ?
             <InlineTagEdit
               post={post}
               user={user}

--- a/src/components/Story/StoryFull.js
+++ b/src/components/Story/StoryFull.js
@@ -570,7 +570,7 @@ class StoryFull extends React.Component {
           : null}
 
           {isModerator ? <div>
-            {!post.flagged && !post.json_metadata.moderator.reviewed || (post.reviewed && isModerator.supermoderator === true) ? <Action
+            {!post.flagged && !post.reviewed || (post.reviewed && isModerator.supermoderator === true) ? <Action
               id="hide"
               className={`${mobileView ? 'StoryFull__mobilebtn' : ''}`}
               primary={true}
@@ -924,7 +924,7 @@ class StoryFull extends React.Component {
           />
         )}
         <div className="StoryFull__topics">
-          { (isModerator && !post.reviewed) || (isModerator && isModerator.supermoderator === true) ?
+          { (isModerator && !post.json_metadata.moderator.reviewed) || (isModerator && isModerator.supermoderator === true) ?
             <InlineTagEdit
               post={post}
               user={user}

--- a/src/components/Story/StoryFull.js
+++ b/src/components/Story/StoryFull.js
@@ -570,7 +570,7 @@ class StoryFull extends React.Component {
           : null}
 
           {isModerator ? <div>
-            {!post.flagged && !post.reviewed || (post.reviewed && isModerator.supermoderator === true) ? <Action
+            {!post.flagged && !post.json_metadata.moderator.reviewed || (post.reviewed && isModerator.supermoderator === true) ? <Action
               id="hide"
               className={`${mobileView ? 'StoryFull__mobilebtn' : ''}`}
               primary={true}


### PR DESCRIPTION
* `src/components/Story/Contribution.js` 
    - enable inline edit for category and repo on unreviewed contribs only
    - added folder icon as link to utopian project page
* `src/components/Story/StoryFull.js`
    - enable inline edit of tags for unreviewed contribs only
