### PR TITLE
Hotfix inline category, repo, and tags not properly set

### DIFF
--- a/src/components/Story/InlineCategoryEdit.js
+++ b/src/components/Story/InlineCategoryEdit.js
@@ -51,9 +51,7 @@ class InlineCategoryEdit extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.value !== nextProps.value) {
-      this.setState({
-        value: nextProps.value,
-      });
+      this.setState({ value: nextProps.value });
     }
   }
 

--- a/src/components/Story/InlineCategoryEdit.js
+++ b/src/components/Story/InlineCategoryEdit.js
@@ -14,15 +14,13 @@ class InlineCategoryEdit extends React.Component {
     value: '',
   };
 
-  constructor (props) {
+  constructor(props) {
     super(props);
-    this.state = {
-        value: props.value
-    }
+    this.state = { value: '' };
     this.onCategoryChange = this.onCategoryChange.bind(this);
   }
 
-  onCategoryChange (e) {
+  onCategoryChange(e) {
     const value = e.target.value;
     this.setState({
         value: e.target.value
@@ -47,18 +45,29 @@ class InlineCategoryEdit extends React.Component {
     });
   }
 
-  render () {
+  componentWillMount() {
+    this.setState({ value: this.props.value });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.value !== nextProps.value) {
+      this.setState({
+        value: nextProps.value,
+      });
+    }
+  }
+
+  render() {
     const types = this.props.types.map((type, idx) => (
       <option value={type.type} key={idx}>{type.slug}</option>
     ))
-    const type = this.props.value;
 
     return (
       <select
         value={this.state.value}
         className="inline-category-edit-select"
         onChange={ this.onCategoryChange }
-		defaultChecked={ this.state.value }>
+        defaultChecked={ this.state.value }>
         {types}
       </select>
     );

--- a/src/components/Story/InlineRepoEdit.js
+++ b/src/components/Story/InlineRepoEdit.js
@@ -31,7 +31,7 @@ class InlineRepoEdit extends React.Component {
   };
 
   state = {
-    value: this.props.value,
+    value: '',
     previousValue: '',
     loading: false,
     loaded: true
@@ -41,6 +41,16 @@ class InlineRepoEdit extends React.Component {
     super(props);
     this.renderItems = this.renderItems.bind(this);
     this.post = props.post
+  }
+
+  componentWillMount() {
+    this.setState({ value: this.props.value });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.value !== nextProps.value) {
+      this.setState({ value: nextProps.value });
+    }
   }
 
   renderItems(items) {
@@ -107,14 +117,14 @@ class InlineRepoEdit extends React.Component {
               q = q.replace('http://', '');
               q = q.replace('github.com/', '');
               q = '"' + q + '"';
-    
+
               if (event.key === 'Enter')
               {
                 event.preventDefault();
               }
-              
+
               this.setState({loading: true, loaded: false});
-              
+
               clearTimeout(this.debounceTimer);
               this.debounceTimer = setTimeout(() => {
                 this.debounceTimer = null;
@@ -154,7 +164,7 @@ class InlineRepoEdit extends React.Component {
           }, () => {
             this.callModeratorAction()
           });
-          
+
         }}
         getItemValue={repo => repo.full_name}
         onChange={(event, value) => {

--- a/src/components/Story/InlineTagEdit.js
+++ b/src/components/Story/InlineTagEdit.js
@@ -109,7 +109,7 @@ class InlineTagEdit extends React.Component {
   handleRemoveTag(event) {
     event.preventDefault();
     const index = parseInt(event.target.attributes['data-index'].value, 10);
-    removeTag(index);
+    this.removeTag(index);
     setTimeout(() => {
       this.updatePostTags();
     }, 100);
@@ -132,7 +132,7 @@ class InlineTagEdit extends React.Component {
     if(event.target.value === '') {
       // remove added tag span when value is empty
       const index = parseInt(event.target.attributes['data-index'].value, 10);
-      removeTag(index);
+      this.removeTag(index);
     } else if (prevTags.sort().join(',') === newTags.sort().join(',')
         || !this.props.validation(newTags)) {
       // do nothing; do not broadcoast

--- a/src/components/Story/InlineTagEdit.js
+++ b/src/components/Story/InlineTagEdit.js
@@ -16,7 +16,6 @@ class InlineTagEdit extends React.Component {
   };
 
   static defaultProps = {
-    value: '',
     user: {},
     post: {},
     moderatorAction: () => {},
@@ -25,11 +24,7 @@ class InlineTagEdit extends React.Component {
 
   constructor (props) {
     super(props);
-
-    this.state = {
-      tags: [],
-    }
-
+    this.state = { tags: [] };
     this.handleRemoveTag = this.handleRemoveTag.bind(this);
     this.removeTag = this.removeTag.bind(this);
     this.resizeInput = this.resizeInput.bind(this);
@@ -48,10 +43,7 @@ class InlineTagEdit extends React.Component {
     const tags = this.post['json_metadata'].tags.map((tag) => {
       return { title: tag };
     });
-
-    this.setState({
-      tags: this.state.tags.concat(tags)
-    });
+    this.setState({ tags: this.state.tags.concat(tags) });
 
     setTimeout(() => {
       const tagInputs = document.getElementsByClassName('inline-tag-edit-input');
@@ -59,6 +51,18 @@ class InlineTagEdit extends React.Component {
         return this.resizeInput(tagInput);
       });
     }, 100);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const prevTags = this.props.post['json_metadata'].tags;
+    const nextTags = nextProps.post['json_metadata'].tags;
+
+    if (prevTags.sort().join(',') !== nextTags.sort().join(',')) {
+      const tags = nextProps.post['json_metadata'].tags.map((tag) => {
+        return { title: tag, selected: false };
+      });
+      this.setState({ tags: tags });
+    }
   }
 
   updatePostTags() {


### PR DESCRIPTION
* `src/components/Story/InlineCategoryEdit.js` 
* `src/components/Story/InlineRepoEdit.js`
* `src/components/Story/InlineTagEdit.js`
    * added setting of values to `state` when changing contributions; this was done mainly by setting incoming properties in `componentWillReceiveProps()` and set them to state
    * added setting of initial value in `componentWillMount()`