### PR TITLE
added per_page parameter to GitHub PR api call

### DIFF
--- a/src/actions/pullRequests.js
+++ b/src/actions/pullRequests.js
@@ -5,7 +5,7 @@ import * as Actions from '../actions/constants';
 export const getPullRequestsRequest = (repository) => ({
   [CALL_API]: {
     types: [ Actions.GET_GITHUB_PR_REQUEST, Actions.GET_GITHUB_PR_SUCCESS, Actions.GET_GITHUB_PR_FAILURE ],
-    endpoint: `https://api.github.com/repos/${repository}/pulls?state=closed`,
+    endpoint: `https://api.github.com/repos/${repository}/pulls?state=closed&per_page=100`,
     schema: null,
     method: 'GET',
     payload: {},


### PR DESCRIPTION
increases number of returned results (for the repository dropdown) from 30 to 100.

hotfixes this one: https://utopian.io/utopian-io/@mkt/can-t-select-my-pull-requests-if-there-are-to-many-new-ones
why there are linked PRs in a bug hunting contribution you ask?... well, this seems to be another bug. :D