### PR TITLE
check if on user's feed by matching the routes that start with a user…

### DIFF
--- a/src/feed/SubFeed.js
+++ b/src/feed/SubFeed.js
@@ -368,8 +368,8 @@ class SubFeed extends React.Component {
           hasMore={hasMore}
           loadMoreContent={this.loadContributions}
           contentType={match.params.type}
-          showBlogs={((match.path === '/@:name') || (match.params.type === 'blog') || (match.params.filterBy === 'review'))}
-          showTasks={(match.path === '/tasks' || (this.isTask()) || (match.params.filterBy === 'review') || (match.path === '/@:name'))}
+          showBlogs={(R.startsWith('/@:name', match.path) || (match.params.type === 'blog') || (match.params.filterBy === 'review'))}
+          showTasks={(match.path === '/tasks' || (this.isTask()) || (match.params.filterBy === 'review') || R.startsWith('/@:name', match.path))}
         />
         {!contributions.length && !isFetching && <EmptyFeed type={match.params.type} />}
       </div>

--- a/src/helpers/image.js
+++ b/src/helpers/image.js
@@ -8,4 +8,7 @@ export const getProxyImageURL = (url, type) => {
   return `${IMG_PROXY}${url}`;
 };
 
+export const MAXIMUM_UPLOAD_SIZE = 52428800;
+export const isValidImage = file => file.type.match('image/.*') && file.size <= MAXIMUM_UPLOAD_SIZE;
+
 export default null;


### PR DESCRIPTION
… name parameter

#475

Tasks and blog posts were not shown on the moderation feed causing users looking at the feed that had their first page a combination of these 2 types of posts to not see anything at all.

This solution is really to show the blog and task type posts in the user moderation feed.
