### PR TITLE
removed duplicate code

### DIFF
--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -12,13 +12,14 @@ import Dropzone from 'react-dropzone';
 import EditorToolbar from './EditorToolbar';
 import * as EditorTemplates from './templates';
 import Action from '../Button/Action';
-import Body, { remarkable } from '../Story/Body';
+import Body from '../Story/Body';
 import Autocomplete from 'react-autocomplete';
 import SimilarPosts from './SimilarPosts';
 import 'mdi/css/materialdesignicons.min.css';
 import './Editor.less';
 
 import { getGithubRepos, setGithubRepos } from '../../actions/projects';
+
 const RadioGroup = Radio.Group;
 const Option = Select.Option;
 
@@ -26,6 +27,29 @@ const Option = Select.Option;
 import { Rules } from '../Rules';
 import { getPullRequests } from '../../actions/pullRequests';
 
+const AcceptRules = ({acceptRules}) => (
+  <Action
+    className="accept-rules-btn"
+    primary
+    text={'I understand. Proceed'}
+    onClick={e => {
+      e.preventDefault();
+      acceptRules();
+    }}
+  />
+);
+
+const SyncGithub = () => (
+  <Action
+    className="accept-rules-btn"
+    disabled
+    primary
+    text={'Your Utopian account must be connected to your GitHub account'}
+    onClick={e => {
+      e.preventDefault();
+    }}
+  />
+);
 
 @connect(
   state => ({
@@ -553,6 +577,7 @@ class Editor extends React.Component {
     const { getFieldDecorator } = this.props.form;
     const { intl, loading, isUpdating, isReviewed, type, saving, getGithubRepos, repos, setGithubRepos, user, getPullRequests, pullRequests, parsedPostData } = this.props;
     const chosenType = this.state.currentType || type || 'ideas';
+    const gitHubConnectionRequired = ['development', 'bug-hunting', 'documentation'].indexOf(chosenType) !== -1;
     const hasGithubSynced = () => {
       if (!user || !user.github || !user.github.lastSynced) return false;
       return (user.github.lastSynced) != null;
@@ -644,11 +669,10 @@ class Editor extends React.Component {
           </div>
         </Form.Item>
 
-        {!this.state.rulesAccepted && !isUpdating  ? <Rules
-            inEditor={true}
-            githubSynced={hasGithubSynced()}
-            type={chosenType}
-            acceptRules={() => this.setState({rulesAccepted: true})} />
+        {!this.state.rulesAccepted && !isUpdating ? <div><Rules
+            type={chosenType} />
+            <small className={'readAllRules'}><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small>
+            {!gitHubConnectionRequired || hasGithubSynced() ? <AcceptRules acceptRules={() => this.setState({rulesAccepted: true})} /> : <SyncGithub />}</div>
           : null}
 
         <div className={this.state.rulesAccepted || isUpdating ? 'rulesAccepted' : 'rulesNotAccepted'}>

--- a/src/components/Editor/Editor.less
+++ b/src/components/Editor/Editor.less
@@ -8,6 +8,11 @@
     margin-bottom: 15px;
   }
 
+  .readAllRules {
+    margin: 15px 0;
+    display: block;
+  }
+
   &__category {
     .ant-radio-group {
       display: flex;

--- a/src/components/Editor/EditorTask.js
+++ b/src/components/Editor/EditorTask.js
@@ -7,16 +7,17 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 import { HotKeys } from 'react-hotkeys';
 import { throttle } from 'lodash';
 import isArray from 'lodash/isArray';
-import { Icon, Checkbox, Form, Input, Select, Radio } from 'antd';
+import { Icon, Form, Input, Select, Radio } from 'antd';
 import Dropzone from 'react-dropzone';
 import EditorToolbar from './EditorToolbar';
 import * as EditorTemplates from './templates';
 import Action from '../Button/Action';
-import Body, { remarkable } from '../Story/Body';
+import Body from '../Story/Body';
 import './Editor.less';
 
 import { RulesTask } from '../RulesTask';
 import { getGithubRepos, setGithubRepos } from '../../actions/projects';
+
 const RadioGroup = Radio.Group;
 
 @connect(
@@ -542,10 +543,10 @@ class EditorTask extends React.Component {
           </div>
         </Form.Item>
 
-        {!this.state.rulesAccepted && !isUpdating  ? <RulesTask
-            inEditor={true}
-            type={chosenType}
-            acceptRules={() => this.setState({rulesAccepted: true})} />
+        {!this.state.rulesAccepted && !isUpdating ? <div><RulesTask
+            type={chosenType} />
+            <small className={'readAllRules'}><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small>
+            <AcceptRules acceptRules={() => this.setState({rulesAccepted: true})} /></div>
           : null}
 
         <div className={this.state.rulesAccepted || isUpdating ? 'rulesAccepted' : 'rulesNotAccepted'}>

--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -1,46 +1,18 @@
 import React from 'react';
 import CategoryIcon from './CategoriesIcons';
-import Action from './Button/Action';
 
-const AcceptRules = ({acceptRules}) => (
-  <Action
-    className="accept-rules-btn"
-    primary
-    text={'I understand. Proceed'}
-    onClick={e => {
-      e.preventDefault();
-      acceptRules();
-    }}
-  />
-);
-
-const SyncGithub = () => (
-  <Action
-    className="accept-rules-btn"
-    disabled
-    primary
-    text={'Your Utopian account must be connected to your GitHub account'}
-    onClick={e => {
-      e.preventDefault();
-    }}
-  />
-);
-
-export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
+export const Rules = ({type}) => {
   switch(type) {
     case 'ideas':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="ideas"/> Suggestion Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>Suggestions are minor features/enhancements that you would like to have in an Open Source project.</li>
             <li>Suggestions may be only related to the technical aspects of the project not process or organisational issues.</li>
             <li>Suggestions must provide all the details for the requested features to be actually built.</li>
             <li>Images, screenshots, links and examples are always welcome in this category.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     /*case 'sub-projects':
@@ -64,7 +36,6 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="development"/> Development Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>In the development category you can submit <b>Bug Fixes</b>, <b>New Features</b> and your <b>Own Projects</b>.</li>
             <li>Contributions must have a comprehensible commit history. Larger projects or updates submitted in a single commit will not be accepted.</li>
@@ -77,15 +48,12 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li><b>Bug Fixes</b> for your <b>Own Projects</b> will not be accepted, unless the Bugs were caused by third party dependencies.</li>
             <li>Your Utopian account must be connected to your GitHub account.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? (githubSynced ? <AcceptRules acceptRules={acceptRules} /> : <SyncGithub />)  : null}
         </div>
       )
     case 'bug-hunting':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="bug-hunting"/> Bug Hunting Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>In this category you can submit <b>Bug Reports</b> for actively maintained Open Source projects on GitHub.</li>
             <li>The repository on GitHub must accept <a href="https://help.github.com/articles/about-issues/">issues</a>.</li>
@@ -98,15 +66,12 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>If you or someone else submitted the issue on GitHub first, the <b>Bug Report</b> will not be accepted. Approved <b>Bug Reports</b> will automatically be published on GitHub.</li>
             <li>Your Utopian account must be connected to your GitHub account.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution will not be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     case 'translations':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="translations"/> Translations Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>This category is meant only for translations you have created or updated for an Open Source project.</li>
             <li>You must translate a minimum of 1000 words per translation contribution.</li>
@@ -124,15 +89,12 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>If the provided translation is obviously machine-translated for more than 20% or has low quality, it will be rejected.</li>
             <li>Proof-reading is not acceptable in Utopian as a valid contribution.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     case 'graphics':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="graphics"/> Graphics Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>This category is meant only for graphics/videos/motion graphics that you have realised for an open source project.</li>
             <li>The contribution must be a direct result of your own work. It is strictly prohibited to modify other people’s work/assets or use a template and claim it as yours.</li>
@@ -148,15 +110,12 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>Banners, header images and other assets for use on social media platforms are not valid contributions at the moment.</li>
             <li>Designs are preferred to be in a vector format unless the project owner specifies a different format.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     case 'analysis':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="analysis"/> Analysis Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>This category is meant only for providing a data analysis you have generated for an Open Source project.</li>
             <li>You must include the results of your analyses and the reasons why you have generated them.</li>
@@ -165,15 +124,12 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>If you are not pasting the entire analysis here you must provide public links to it.</li>
             <li>Results of the analyses, in the form of charts or tables are mandatory in this category.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     case 'social':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="analysis"/> Visibility Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>This category is meant only for providing results of <b>online social engagement</b>, ads and similar for an Open Source project.</li>
             <li>Promotions done on chats (e.g. Whatsapp, Telegram and similar) won't be accepted as valid contributions.</li>
@@ -182,15 +138,12 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>You must include links and proofs of the visibility effort you made and write down the results.</li>
             <li>You must provide a clear way to recognise you are the author of the social effort, by matching your Steem/Utopian account with the one on the social platforms or by using any other field to immediately verify that.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     case 'documentation':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="documentation"/> Documentation Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>Only merged Pull Requests on the official repository will be accepted or on a fork as long as the fork is not just a mirror of the original one.</li>
             <li>This category is meant only when working on the Official documentation of an Open Source project.</li>
@@ -199,15 +152,12 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>If you are not pasting the entire documentation here you must provide public links to it.</li>
             <li>You must link Pull Requests you have submitted on Github for the official documentation using the functionality provided in the editor.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     case 'tutorials':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="tutorials"/> Tutorial Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>Tutorials must be technical instructions that teach non-trivial aspects of an Open Source project.</li>
             <li>Design or video editing related tutorials, gameplay, simple on-screen instructions, ubiquitous functions (Save, Open, Print, etc.) or basic programming concepts (variables, operators, loops, etc.) will not be accepted.</li>
@@ -217,15 +167,12 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>If you include a video covering the full tutorial, use the Video Tutorial category. You can not share the same tutorial in both categories.</li>
             <li>If you create a GitHub repository with additional material (like code samples), make sure to choose the repository of the project your tutorial is about and not your own repository. You can provide links to your repository in your post.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     case 'video-tutorials':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="video-tutorials"/> Video Tutorial Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>Video Tutorials must be technical instructions that teach non-trivial aspects of an Open Source project.</li>
             <li>Design or video editing related tutorials, gameplay, simple on-screen instructions, ubiquitous functions (Save, Open, Print, etc.) or basic programming concepts (variables, operators, loops, etc.) will not be accepted.</li>
@@ -238,30 +185,24 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>If you provide a text version of your tutorial, you need to include it or a link to it in your post. You can not submit a separate contribution in the Tutorial category.</li>
             <li>If you create a GitHub repository with additional material (like code samples), make sure to choose the repository of the project your tutorial is about and not your own repository. You can provide links to your repository in your post.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     case 'copywriting':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="copywriting"/> Copywriting Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>This category is meant only for showing copywriting work you have completed for an Open Source project.</li>
             <li>Linking pull requests from Github is encouraged, but not required if not applicable. </li>
             <li>You must be the author of the copywriting work and provide a clear way to verify that.</li>
             <li><a href="https://en.wikipedia.org/wiki/Copywriting">Read the official Wikipedia explanation for what acceptable Copywriting work is.</a></li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
     case 'blog':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="blog"/> Blog Post Rules</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
         <li>You must provide an original and unique editorial content of very high quality, not only news found on the web or general thoughts.</li>
         <li>Blogs must be strongly related to the promotion and development of an open-source project.</li>
@@ -270,9 +211,6 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
         <li>Blog posts must provide detailed content and overviews related to the open-source projects.</li>
         <li>Images, screenshots, links and examples are not necessary but preferred.</li>
           </ul>
-          <p>Not respecting the rules will either give you lower votes or your contribution won't be accepted.
-          </p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
       )
   }

--- a/src/components/RulesTask.js
+++ b/src/components/RulesTask.js
@@ -1,131 +1,102 @@
 import React from 'react';
 import CategoryIcon from './CategoriesIcons';
-import Action from './Button/Action';
 
-const AcceptRules = ({acceptRules}) => (
-  <Action
-    className="accept-rules-btn"
-    primary
-    text='I understand. Proceed'
-    onClick={e => {
-      e.preventDefault();
-      acceptRules();
-    }}
-  />
-);
-
-export const RulesTask = ({type, acceptRules, inEditor}) => {
+export const RulesTask = ({type}) => {
   switch(type) {
     case 'task-ideas':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="ideas"/> Conceptors/Thinkers</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>By submitting a task request in this category you are requesting contributors to provide concepts and ideas.</li>
             <li>You must provide great details about what you are looking for and the problems you want to solve with a concept.</li>
             <li>Images, screenshots, links and examples are always welcome in this category.</li>
           </ul>
           <p>Not respecting the rules will either give you lower exposure or your task request won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} /> : null}
         </div>
       )
     case 'task-development':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="development"/> Developers</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>In this category you can only write if you are looking for developers joining your crew.</li>
             <li>You must provide all the details for the developers to contribute to your project.</li>
             <li>Documentation, Repositories, Communities (e.g. Slack, Discord) and specific details are necessary.</li>
           </ul>
           <p>Not respecting the rules will either give you lower exposure or your task request won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} /> : null}
         </div>
       )
     case 'task-bug-hunting':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="bug-hunting"/> Bug Hunters</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>In this category you can only post if you are looking to spot bugs in your system/software/website and similar.</li>
             <li>You must provide every possible detail for the bug hunters to be able to start the hunting.</li>
             <li>You must include for example browsers, devices, operating systems and similar info where you want bugs to be spotted.</li>
           </ul>
           <p>Not respecting the rules will either give you lower exposure or your task request won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} /> : null}
         </div>
       )
     case 'task-translations':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="translations"/> Translators</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>You can only post in this category if you are looking for translators to translate your project.</li>
             <li>You must provide any necessary information for the translators to start their work.</li>
             <li>Location of the files to be translated, tools to use, languages you are looking for and similar info are necessary.</li>
           </ul>
           <p>Not respecting the rules will either give you lower exposure or your task request won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} /> : null}
         </div>
       )
     case 'task-graphics':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="graphics"/> Designers</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>You can only post in this category if you are looking for designers to join your Open Source project.</li>
             <li>You must provide exactly what you are looking and how would you like it to be in great details.</li>
             <li>Whether you are looking for a logo, layout, banner or similar, your request has to be very specific.</li>
           </ul>
           <p>Not respecting the rules will either give you lower votes or your announcement won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} /> : null}
         </div>
       )
     case 'task-documentation':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="documentation"/> Tech Writers</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>This category is meant only for requiring help in updating/creating the documentation of your Open Source project.</li>
             <li>You must be very specific about which part of the documentation you wish to update/create.</li>
             <li>It is important to provide the tools you wish to use and necessary info for the documentation to be actually written.</li>
           </ul>
           <p>Not respecting the rules will either give you lower exposure or your task request won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} /> : null}
         </div>
       )
     case 'task-analysis':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="analysis"/> Data Analysts</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>This category is meant only for requesting data analysis for your Open Source project.</li>
             <li>Your request must be very specific about the numbers you wish to extract.</li>
             <li>You must provide the tools and all the information necessary for the analyses to be actually completed.</li>
           </ul>
           <p>Not respecting the rules will either give you lower exposure or your task request won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} /> : null}
         </div>
       )
     case 'task-social':
       return (
         <div className="Editor__rules">
           <h2><CategoryIcon from="from-rules"  type="analysis"/> Influencers</h2>
-          {inEditor ? <p><small><a href="https://utopian.io/rules" target="_blank">Read all the rules</a></small></p> : null}
           <ul>
             <li>This category is meant only for requesting help of social influencers in spreading the word about your project.</li>
             <li>You must provide any possible detail for the influencers to effectively share your Open Source project.</li>
             <li>You must also provide any graphic, video and similar digital goods the influencers are supposed to share.</li>
           </ul>
           <p>Not respecting the rules will either give you lower exposure or your task request won't be accepted.</p>
-          {inEditor ? <AcceptRules acceptRules={acceptRules} /> : null}
         </div>
       )
   }


### PR DESCRIPTION
**NEEDS TO BE TESTED ON STAGING:** Tested for normal contributions but I wasn't able to test for Task Requests. I was able to connect to GitHub but couldn't load my repos...

Moved button "I understand. Proceed" and link "Read all the rules" to [Editor(Task).js](https://github.com/utopian-io/utopian.io/pull/493/files#diff-8164c01394f1e52ca1720d09f2fa169cR674) instead of [repeating them over and over again for every category](https://github.com/utopian-io/utopian.io/pull/493/files#diff-927d5db87111f9a6a5f50ecf409b36eeL35) in the files containing the rules.

![image](https://user-images.githubusercontent.com/6792578/37506913-6e72c03c-28ec-11e8-8932-f1d85bf81c66.png)
("Read all the rules" moved below the rules box... deal with it. :P)

Side effect: Check for GitHub connection now works also for Documentation and Bug Hunting category.

![image](https://user-images.githubusercontent.com/6792578/37506964-b2520c72-28ec-11e8-8370-f9a1605b843a.png)

also removed unused imports from those files...........