### PR TITLE
moved important rule to top and improved style/spacings

### DIFF
--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -37,7 +37,7 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>Suggestions are minor features / enhancements to an Open Source project.</li>
             <li>Suggestions may only relate to significant technical aspects of the project (rather than processes or organisational issues).</li>
             <li>Suggestions must provide all the information and details for the requested features to be actualized.</li>
-            <li>Images, charts, screenshots, links and examples should be included contributions to this category.</li>
+            <li><i>Images, charts, screenshots, links and examples should be included contributions to this category.</i></li>
           </ul>
           {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
@@ -81,7 +81,7 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>Submissions must refer to bugs on the latest released version of the application (not older versions).</li>
             <li>Submission title must briefly describe the occuring issue and include searchable keywords.</li>
             <li>Bug Reports previously submitted as issues on GitHub (either by the contribution author or another party), will not be accepted. Approved Bug Reports will automatically be published on GitHub.</li>
-            <li>Submissions should include screenshots, video recordings or animated GIFs if they can help to describe and understand the bug reported.</li>
+            <li><i>Submissions should include screenshots, video recordings or animated GIFs if they can help to describe and understand the bug reported.</i></li>
           </ul>
           {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>
@@ -140,7 +140,7 @@ export const Rules = ({type, acceptRules, inEditor, githubSynced}) => {
             <li>Intro videos are acceptable only if the contributed video replaces an existing one of inferior quality already included in the project or if it was explicitly requested by the project owner.</li>
             <li>All submissions must be licensed under the <a href="https://creativecommons.org/choose/" target={'_blank'}>creative commons license</a>.</li>
             <li>All designs should be delivered in a vector format unless otherwise specified by the project owner.</li>
-            <li>Submissions should (ideally) be coordinated with the project owner throughout the design process.</li>
+            <li><i>Submissions should (ideally) be coordinated with the project owner throughout the design process.</i></li>
           </ul>
           {inEditor ? <AcceptRules acceptRules={acceptRules} />  : null}
         </div>

--- a/src/components/RulesTask.js
+++ b/src/components/RulesTask.js
@@ -27,7 +27,7 @@ export const RulesTask = ({type, acceptRules, inEditor}) => {
           <ul>
             <li>Submissions to this tasks category must describe in great detail the requirements and needs of the project manager.</li>
             <li>Submissions must include details defining what you are looking for and the problems you want to solve with a concept.</li>
-            <li>Images, screenshots, links and examples should be included as part of the submission.</li>
+            <li><i>Images, screenshots, links and examples should be included as part of the submission.</i></li>
           </ul>
           {inEditor ? <AcceptRules acceptRules={acceptRules} /> : null}
         </div>

--- a/src/statics/Rules.js
+++ b/src/statics/Rules.js
@@ -130,7 +130,7 @@ export default props =>
         <li>The contribution should not contain any clear attempt to profit solely from a commercial perspective, and should not be written in a way that suggests the contributor is looking to maximise the returns.</li>
         <li>The author may include links to his social profiles in his submission if they appear in a non-disruptive way.</li>
         <li>Links to commercial products and affiliate links are forbidden.</li>
-        <li>Tagging or mentioning other Steem / Utopian users without an appropriate reason should be avoided.</li>
+        <li><i>Tagging or mentioning other Steem / Utopian users without an appropriate reason should be avoided.</i></li>
       </ul>
       <h3>Defamation</h3>
       <ul>
@@ -140,9 +140,9 @@ export default props =>
       <h3>Solicitation</h3>
       <ul>
         <li>Contributors should not use submission posts to solicit for any activity that it is not strictly accepted by Utopian Rules.</li>
-        <li>Contributors should not ask for Steem / Steemit engagement (upvotes, resteems and follows) in their contribution posts.</li>
-        <li>Contributors should not ask for Utopian engagement (upvotes and follows) in their contribution posts.</li>
-        <li>Contributors may ask for Steem witness votes in a short request (one paragraph) at the footer of their post.</li>
+        <li><i>Contributors should not ask for Steem / Steemit engagement (upvotes, resteems and follows) in their contribution posts.</i></li>
+        <li><i>Contributors should not ask for Utopian engagement (upvotes and follows) in their contribution posts.</i></li>
+        <li><i>Contributors may ask for Steem witness votes in a short request (one paragraph) at the footer of their post.</i></li>
       </ul>
       <h3>Religious / Political Content</h3>
       <ul>

--- a/src/statics/Rules.js
+++ b/src/statics/Rules.js
@@ -10,11 +10,21 @@ export default props =>
     <div className="container text-center my-5">
 
       <h1>General Rules</h1>
+
+      <p>
+        These are the rules that apply, if you want to submit a contribution to Utopian. If you have more general questions about Utopian please refer to our <NavLink className="CookiePolicyBanner__PolicyLink" to="/faq">Frequently Asked Questions</NavLink>.
+      </p>
+
       <p>
         <b>Failing to adhere to one or more of the rules set below will lead to the immediate rejection of your contribution. Please be sure to read and understand the rules before submitting a contribution.</b>
       </p>
+
       <p>
-        If you have more general questions about Utopian please refer to our <NavLink className="CookiePolicyBanner__PolicyLink" to="/faq">Frequently Asked Questions</NavLink>.
+        <b>Utopian moderators / supervisors have the full right to reject or accept submissions and to assess its quality, even if the submission meets all the rules.</b>
+      </p>
+
+      <p>
+        <b>Supervisors may revert an accepted / rejected contribution.</b>
       </p>
 
       <h2>Rules vs Guidelines</h2>
@@ -183,13 +193,7 @@ export default props =>
       </div>
 
       <div>
-        <h1>Moderation</h1>
-        <ul>
-          <li>Utopian moderators / supervisors have the full right to reject or accept submissions and to assess its quality, even if the submission meets all the rules.</li>
-          <li>Supervisors may revert an accepted / rejected contribution.</li>
-        </ul>
-
-        <h2>Reporting a Moderation Issue</h2>
+        <h1>Reporting a Moderation Issue</h1>
         <p>
           Get in touch with the Supervisor assigned to the moderator that reviewed your submission. <a href="https://docs.google.com/spreadsheets/u/1/d/11AqLQPgULU4F7fIwfArqYdAcexufSH3IBEY32yVVm4I/edit?usp=drive_web" target={'_blank'}>Find them on this document</a>.
         </p>

--- a/src/statics/Rules.less
+++ b/src/statics/Rules.less
@@ -1,23 +1,28 @@
-.rules-section{
-  padding: 15px;
+.rules-section {
+  padding-bottom: 50px;
+
+  h1 {
+    margin-top: 50px;
+  }
 
   h2 {
+    margin-top: 25px;
+  }
+
+  h3 {
     margin-top: 15px;
   }
 
-  ul  {
-    padding-bottom: 15px;
-    list-style: disc;
-    list-style-position: inside;
-
-    li {
-      margin-top: 15px;
-    }
+  p {
+    margin: 10px 0;
   }
-}
-.Editor__rules {
-  list-style-position: inside;
-}
-.from-rules.md-react-icon {
-  margin-bottom: 5px;
+
+  ul {
+    list-style: disc inside;
+  }
+
+  .Editor__rules {
+    background: transparent;
+    padding: 0;
+  }
 }


### PR DESCRIPTION
I think this *"Utopian moderators / supervisors have the full right to reject or accept submissions and to assess its quality, even if the submission meets all the rules."* should go to the top.

Also fixed those spacings that were tighter than your girlfriend...

...and enclosed all guideline-rules in \<i>\</i>

before:
![image](https://user-images.githubusercontent.com/6792578/37561795-3dd70038-2a58-11e8-902c-a7af96dd6c92.png)

after:
![image](https://user-images.githubusercontent.com/6792578/37561798-5474a9c6-2a58-11e8-9d6c-d86343e5286e.png)

WOW!