### PR TITLE
Fix SBD rate

### DIFF
--- a/common/constants/cryptos.js
+++ b/common/constants/cryptos.js
@@ -601,7 +601,7 @@ export const FTC = {
 export const SBD = {
   id: 'steem-dollars',
   name: 'Steem Dollars',
-  symbol: 'SBD',
+  symbol: 'SBD*',
 };
 
 export const CRYPTO_MAP = {


### PR DESCRIPTION
Hello Utopian Team,
With the CryptoCompare API change, the SBD endpoint has been changed to SBD *
This is why the SBD value on the Wallet page is not displayed or displayed incorrectly.